### PR TITLE
Fix NullPointer during multi-threaded builds

### DIFF
--- a/src/main/java/me/qoomon/maven/extension/gitversioning/VersioningPomReplacementMojo.java
+++ b/src/main/java/me/qoomon/maven/extension/gitversioning/VersioningPomReplacementMojo.java
@@ -10,9 +10,7 @@ import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.*;
 import org.apache.maven.project.MavenProject;
-import org.codehaus.plexus.logging.Logger;
 
-import javax.inject.Inject;
 import java.io.File;
 import java.io.IOException;
 
@@ -31,25 +29,19 @@ public class VersioningPomReplacementMojo extends AbstractMojo {
 
     static final String GOAL = "pom-replacement";
 
+    @Parameter(defaultValue = "${project}", readonly = true, required = true)
+    private MavenProject currentProject;
+
+    @Parameter(defaultValue = "${session}", readonly = true, required = true)
     private MavenSession mavenSession;
-
-    private Logger logger;
-
-    @Inject
-    public VersioningPomReplacementMojo(Logger logger, MavenSession mavenSession) {
-        this.mavenSession = mavenSession;
-        this.logger = logger;
-    }
 
     @Override
     public synchronized void execute() throws MojoExecutionException, MojoFailureException {
 
         try {
-            MavenProject currentProject = mavenSession.getCurrentProject();
-
             GAV gav = GAV.of(currentProject);
 
-            logger.debug(gav + "remove plugin");
+            getLog().debug(gav + "remove plugin");
 
             currentProject.getOriginalModel().getBuild().removePlugin(asPlugin());
 
@@ -80,7 +72,7 @@ public class VersioningPomReplacementMojo extends AbstractMojo {
 
         ModelUtil.writeModel(project.getOriginalModel(), tmpPomFile);
 
-        logger.debug(project.getArtifact() + " temporary override pom file with " + tmpPomFile);
+        getLog().debug(project.getArtifact() + " temporary override pom file with " + tmpPomFile);
 
         project.setPomFile(tmpPomFile);
     }


### PR DESCRIPTION
When I do multi-threaded builds (mvn install -T4), I get the following NullPointer:
```
Caused by: java.lang.NullPointerException
    at me.qoomon.maven.GAV.of (GAV.java:74)
    at me.qoomon.maven.extension.gitversioning.VersioningPomReplacementMojo.execute (VersioningPomReplacementMojo.java:50)
    at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo (DefaultBuildPluginManager.java:134)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:208)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:154)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:146)
    at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject (LifecycleModuleBuilder.java:117)
    at org.apache.maven.lifecycle.internal.builder.multithreaded.MultiThreadedBuilder$1.call (MultiThreadedBuilder.java:200)
    at org.apache.maven.lifecycle.internal.builder.multithreaded.MultiThreadedBuilder$1.call (MultiThreadedBuilder.java:196)
    at java.util.concurrent.FutureTask.run (FutureTask.java:266)
    at java.util.concurrent.Executors$RunnableAdapter.call (Executors.java:511)
    at java.util.concurrent.FutureTask.run (FutureTask.java:266)
    at java.util.concurrent.ThreadPoolExecutor.runWorker (ThreadPoolExecutor.java:1149)
    at java.util.concurrent.ThreadPoolExecutor$Worker.run (ThreadPoolExecutor.java:624)
    at java.lang.Thread.run[INFO] 
```

This PR fixes that by letting Maven inject the right MavenProject object rather than trying to fetch it from the MavenSession object.