### PR TITLE
Bugfix: project model collision

### DIFF
--- a/src/main/java/me/qoomon/maven/gitversioning/ModelProcessor.java
+++ b/src/main/java/me/qoomon/maven/gitversioning/ModelProcessor.java
@@ -133,7 +133,7 @@ public class ModelProcessor extends DefaultModelProcessor {
             gitVersionDetails = getGitVersionDetails(config, projectModel);
         }
 
-        Model virtualProjectModel = this.virtualProjectModelCache.get(projectModel.getArtifactId());
+        Model virtualProjectModel = this.virtualProjectModelCache.get(getCacheKey(projectModel));
         if (virtualProjectModel == null) {
             logger.info(projectGav.getArtifactId() + " - set project version to " + gitVersionDetails.getVersion()
                     + " (" + gitVersionDetails.getCommitRefType() + ":" + gitVersionDetails.getCommitRefName() + ")");
@@ -184,7 +184,7 @@ public class ModelProcessor extends DefaultModelProcessor {
             boolean updatePomOption = getUpdatePomOption(config, gitVersionDetails);
             addBuildPlugin(virtualProjectModel, updatePomOption);
 
-            this.virtualProjectModelCache.put(projectModel.getArtifactId(), virtualProjectModel);
+            this.virtualProjectModelCache.put(getCacheKey(projectModel), virtualProjectModel);
         }
         return virtualProjectModel;
     }
@@ -339,5 +339,9 @@ public class ModelProcessor extends DefaultModelProcessor {
         }
 
         return updatePomOption;
+    }
+
+    private static String getCacheKey(Model projectModel) {
+        return projectModel.getGroupId() + "." + projectModel.getArtifactId();
     }
 }

--- a/src/test/resources/testProjects/multiModuleProject/duplicate-artifactid-different-groupid/pom.xml
+++ b/src/test/resources/testProjects/multiModuleProject/duplicate-artifactid-different-groupid/pom.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>multi-module-project</groupId>
+        <artifactId>main</artifactId>
+        <version>0.0.0</version>
+    </parent>
+
+    <artifactId>logic</artifactId>
+    <groupId>multi-module-project2</groupId>
+
+    <dependencies>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>api</artifactId>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/src/test/resources/testProjects/multiModuleProject/pom.xml
+++ b/src/test/resources/testProjects/multiModuleProject/pom.xml
@@ -16,6 +16,7 @@
     <modules>
         <module>api</module>
         <module>logic</module>
+        <module>duplicate-artifactid-different-groupid</module>
     </modules>
 
     <dependencyManagement>


### PR DESCRIPTION
In a multimodel project, when the artifact id of 2 (sub)projects are the same, but the groupids are different, you get errors due to a collision.

- The virtualProjectModelCache now includes the groupid to fix this problem.
- An integration test is added to the this situation