### PR TITLE
Add the capability to update properties values

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,11 @@ Create `${basedir}/.mvn/maven-git-versioning-extension.xml`.
 - `<branch>` specific version format definition.
     - `<pattern>` An arbitrary regex to match branch names (has to be a **full match pattern** e.g. `feature/.+` )
     - `<versionFormat>` An arbitrary string, see [Version Format & Placeholders](#version-format--placeholders)
+    - `<property>` A property definition to update the value of a property
+        - `<pattern>` The name of the property to update
+        - `<value>` The definition of the new property value
+            - `<pattern>` An arbitrary regex to match property value
+            - `<format>` The new value of the property, see [Version Format & Placeholders](#version-format--placeholders)
     - *optional* `<updatePom>` Enable(`true`) or disable(`false`) version update in original pom fill (will override global `<updatePom>` value)
     - ⚠ **considered if...**
         * HEAD attached to a branch `git checkout <BRANCH>`<br>
@@ -83,6 +88,11 @@ Create `${basedir}/.mvn/maven-git-versioning-extension.xml`.
 - `<tag>` specific version format definition.
     - `<pattern>` An arbitrary regex to match tag names (has to be a **full match pattern** e.g. `v[0-9].*` )
     - `<versionFormat>` An arbitrary string, see [Version Format & Placeholders](#version-format--placeholders)
+    - `<property>` A property definition to update the value of a property
+        - `<pattern>` The name of the property to update
+        - `<value>` The definition of the new property value
+            - `<pattern>` An arbitrary regex to match property value
+            - `<format>` The new value of the property, see [Version Format & Placeholders](#version-format--placeholders)
     - *optional* `<updatePom>` Enable(`true`) or disable(`false`) version update in original pom fill (will override global `<updatePom>` value)
     - ⚠ **considered if...**
         * HEAD is detached `git checkout <TAG>`<br>
@@ -90,6 +100,11 @@ Create `${basedir}/.mvn/maven-git-versioning-extension.xml`.
   
 - `<commit>` specific version format definition.
     - `<versionFormat>` An arbitrary string, see [Version Format & Placeholders](#version-format--placeholders)
+    - `<property>` A property definition to update the value of a property
+        - `<pattern>` The name of the property to update
+        - `<value>` The definition of the new property value
+            - `<pattern>` An arbitrary regex to match property value
+            - `<format>` The new value of the property, see [Version Format & Placeholders](#version-format--placeholders)
     - ⚠ **considered if...**
         * HEAD is detached `git checkout <COMMIT>` and no matching version tag is pointing to HEAD<br>
 

--- a/src/main/java/me/qoomon/gitversioning/GitVersionDetails.java
+++ b/src/main/java/me/qoomon/gitversioning/GitVersionDetails.java
@@ -10,15 +10,18 @@ public class GitVersionDetails {
     private final String commitRefName;
     private final Map<String,String> metaData;
     private final String version;
+    private final Map<String,String> properties;
 
     public GitVersionDetails(final boolean clean,
                              final String commit,
                              final String commitRefType, final String commitRefName,
                              final Map<String, String> metaData,
-                             final String version) {
+                             final String version,
+                             final Map<String, String> properties) {
         this.clean = clean;
         this.metaData = metaData;
         this.version = version;
+        this.properties = properties;
         this.commit = commit;
         this.commitRefType = commitRefType;
         this.commitRefName = commitRefName;
@@ -42,6 +45,10 @@ public class GitVersionDetails {
 
     public Map<String, String> getMetaData() {
         return metaData;
+    }
+
+    public Map<String, String> getProperties() {
+        return properties;
     }
 
     public String getVersion() {

--- a/src/main/java/me/qoomon/gitversioning/PropertyDescription.java
+++ b/src/main/java/me/qoomon/gitversioning/PropertyDescription.java
@@ -1,0 +1,33 @@
+package me.qoomon.gitversioning;
+
+public class PropertyDescription {
+
+    private String pattern;
+
+    private PropertyValueDescription value;
+
+    public PropertyDescription() {
+        this(null, null);
+    }
+
+    public PropertyDescription(String pattern, PropertyValueDescription value) {
+        setPattern(pattern);
+        setValue(value);
+    }
+
+    public String getPattern() {
+        return pattern;
+    }
+
+    public void setPattern(String pattern) {
+        this.pattern = pattern;
+    }
+
+    public PropertyValueDescription getValue() {
+        return value;
+    }
+
+    public void setValue(PropertyValueDescription value) {
+        this.value = value;
+    }
+}

--- a/src/main/java/me/qoomon/gitversioning/PropertyValueDescription.java
+++ b/src/main/java/me/qoomon/gitversioning/PropertyValueDescription.java
@@ -1,0 +1,32 @@
+package me.qoomon.gitversioning;
+
+public class PropertyValueDescription {
+
+    private String pattern;
+
+    private String format;
+
+    public PropertyValueDescription() {
+    }
+
+    public PropertyValueDescription(String pattern, String format) {
+        setPattern(pattern);
+        setFormat(format);
+    }
+
+    public String getPattern() {
+        return pattern;
+    }
+
+    public void setPattern(String pattern) {
+        this.pattern = pattern;
+    }
+
+    public String getFormat() {
+        return format;
+    }
+
+    public void setFormat(String format) {
+        this.format = format;
+    }
+}

--- a/src/main/java/me/qoomon/gitversioning/VersionDescription.java
+++ b/src/main/java/me/qoomon/gitversioning/VersionDescription.java
@@ -1,18 +1,27 @@
 package me.qoomon.gitversioning;
 
+import java.util.List;
+
 public class VersionDescription {
 
     private String pattern;
 
     private String versionFormat;
 
+    private List<PropertyDescription> properties;
+
     public VersionDescription() {
         this(null, null);
     }
 
     public VersionDescription(String pattern, String versionFormat) {
+        this(pattern, versionFormat, null);
+    }
+
+    public VersionDescription(String pattern, String versionFormat, List<PropertyDescription> properties) {
         setPattern(pattern);
         setVersionFormat(versionFormat);
+        setProperties(properties);
     }
 
     public String getPattern() {
@@ -29,6 +38,14 @@ public class VersionDescription {
 
     public void setVersionFormat(final String versionFormat) {
         this.versionFormat = versionFormat != null ? versionFormat : "${commit}";
+    }
+
+    public List<PropertyDescription> getProperties() {
+        return properties;
+    }
+
+    public void setProperties(List<PropertyDescription> properties) {
+        this.properties = properties;
     }
 }
 

--- a/src/main/java/me/qoomon/maven/gitversioning/Configuration.java
+++ b/src/main/java/me/qoomon/maven/gitversioning/Configuration.java
@@ -32,7 +32,6 @@ public class Configuration {
     public static class CommitVersionDescription {
 
         public String versionFormat;
-        @JacksonXmlElementWrapper(useWrapping = false)
         public List<PropertyDescription> property = new ArrayList<>();
         public Boolean updatePom;
     }

--- a/src/main/java/me/qoomon/maven/gitversioning/Configuration.java
+++ b/src/main/java/me/qoomon/maven/gitversioning/Configuration.java
@@ -24,12 +24,28 @@ public class Configuration {
 
         public String pattern;
         public String versionFormat;
+        @JacksonXmlElementWrapper(useWrapping = false)
+        public List<PropertyDescription> property = new ArrayList<>();
         public Boolean updatePom;
     }
 
     public static class CommitVersionDescription {
 
         public String versionFormat;
+        @JacksonXmlElementWrapper(useWrapping = false)
+        public List<PropertyDescription> property = new ArrayList<>();
         public Boolean updatePom;
+    }
+
+    public static class PropertyDescription {
+
+        public String pattern;
+        public PropertyValueDescription value;
+    }
+
+    public static class PropertyValueDescription {
+
+        public String pattern;
+        public String format;
     }
 }

--- a/src/test/java/me/qoomon/maven/gitversioning/ConfigurationTest.java
+++ b/src/test/java/me/qoomon/maven/gitversioning/ConfigurationTest.java
@@ -90,6 +90,82 @@ class ConfigurationTest {
     }
 
     @Test
+    void xmlUnmarshaller_branchConfigsOnlyWithProperties() throws IOException {
+        // given
+        String configXml = "" +
+                "<gitVersioning>\n" +
+                "    <branch>\n" +
+                "        <pattern>branch1-pattern</pattern>\n" +
+                "        <versionFormat>branch1-format</versionFormat>\n" +
+                "        <property>\n" +
+                "            <pattern>my.property</pattern>\n" +
+                "            <value>\n" +
+                "                <pattern>my.property.pattern</pattern>\n" +
+                "                <format>my.property.format</format>\n" +
+                "            </value>\n" +
+                "        </property>\n" +
+                "    </branch>\n" +
+                "    <branch>\n" +
+                "        <pattern>branch2-pattern</pattern>\n" +
+                "        <versionFormat>branch2-format</versionFormat>\n" +
+                "        <property>\n" +
+                "            <pattern>my.first.property</pattern>\n" +
+                "            <value>\n" +
+                "                <pattern>my.first.property.pattern</pattern>\n" +
+                "                <format>my.first.property.format</format>\n" +
+                "            </value>\n" +
+                "        </property>\n" +
+                "        <property>\n" +
+                "            <pattern>my.second.property</pattern>\n" +
+                "            <value>\n" +
+                "                <pattern>my.second.property.pattern</pattern>\n" +
+                "                <format>my.second.property.format</format>\n" +
+                "            </value>\n" +
+                "        </property>\n" +
+                "    </branch>\n" +
+                "</gitVersioning>\n";
+
+        // when
+        Configuration config = new XmlMapper()
+                .readValue(configXml, Configuration.class);
+
+        // then
+        assertAll(
+                () -> assertThat(config.commit).isNull(),
+                () -> assertThat(config.branch)
+                        .satisfies(branchConfigs -> assertAll(
+                                () -> assertThat(branchConfigs).hasSize(2),
+                                () -> assertThat(branchConfigs.get(0)).satisfies(branchConfig -> assertAll(
+                                        () -> assertThat(branchConfig.pattern).isEqualTo("branch1-pattern"),
+                                        () -> assertThat(branchConfig.versionFormat).isEqualTo("branch1-format"),
+                                        () -> assertThat(branchConfig.property).hasSize(1),
+                                        () -> assertThat(branchConfig.property.get(0)).satisfies(branchPropertyConfig -> assertAll(
+                                                () -> assertThat(branchPropertyConfig.pattern).isEqualTo("my.property"),
+                                                () -> assertThat(branchPropertyConfig.value.pattern).isEqualTo("my.property.pattern"),
+                                                () -> assertThat(branchPropertyConfig.value.format).isEqualTo("my.property.format")
+                                        ))
+                                )),
+                                () -> assertThat(branchConfigs.get(1)).satisfies(branchConfig -> assertAll(
+                                        () -> assertThat(branchConfig.pattern).isEqualTo("branch2-pattern"),
+                                        () -> assertThat(branchConfig.versionFormat).isEqualTo("branch2-format"),
+                                        () -> assertThat(branchConfig.property).hasSize(2),
+                                        () -> assertThat(branchConfig.property.get(0)).satisfies(branchPropertyConfig -> assertAll(
+                                                () -> assertThat(branchPropertyConfig.pattern).isEqualTo("my.first.property"),
+                                                () -> assertThat(branchPropertyConfig.value.pattern).isEqualTo("my.first.property.pattern"),
+                                                () -> assertThat(branchPropertyConfig.value.format).isEqualTo("my.first.property.format")
+                                        )),
+                                        () -> assertThat(branchConfig.property.get(1)).satisfies(branchPropertyConfig -> assertAll(
+                                                () -> assertThat(branchPropertyConfig.pattern).isEqualTo("my.second.property"),
+                                                () -> assertThat(branchPropertyConfig.value.pattern).isEqualTo("my.second.property.pattern"),
+                                                () -> assertThat(branchPropertyConfig.value.format).isEqualTo("my.second.property.format")
+                                        ))
+                                ))
+                        )),
+                () -> assertThat(config.tag).isEmpty()
+        );
+    }
+
+    @Test
     void xmlUnmarshaller_tagsConfigsOnly() throws IOException {
         // given
         String configXml = "" +


### PR DESCRIPTION
This PR adds the capability to update properties values as well. This is relevant when working simultaneously on 2 dependent projects, as described in https://github.com/qoomon/maven-git-versioning-extension/issues/41.

This improvement allows to define configuration as follows:
```xml
<branch>
    <pattern><![CDATA[feature/(?<feature>.+)]]></pattern>
    <versionFormat>${version.release}-${feature}-SNAPSHOT</versionFormat>
    <property>
        <pattern>my.property.name</pattern>
        <value>
            <pattern><![CDATA[(?<propertyVersion>.+?)(-SNAPSHOT)]]></pattern>
            <format>${propertyVersion}-${feature}-SNAPSHOT</format>
        </value>
    </property>
</branch>
```

In this example the property `my.property.name`, if exists, if it matches the pattern <projectVersion>-SNAPSHOT and if the current branch matches the pattern `feature/<featureName>`, will be set to `<projectVersion>-<featureName>-SNAPSHOT`.