### PR TITLE
Added support for commit date time to make the version sequential

### DIFF
--- a/src/main/java/me/qoomon/gitversioning/GitRepoSituation.java
+++ b/src/main/java/me/qoomon/gitversioning/GitRepoSituation.java
@@ -12,19 +12,19 @@ public class GitRepoSituation {
     private boolean clean;
     private String headCommit;
     private String headBranch;
-    private Date headCommitDate;
+    private long headCommitTimestamp;
     private List<String> headTags;
 
     public GitRepoSituation(){
-        this(true, NO_COMMIT, null, emptyList(), null);
+        this(true, NO_COMMIT, null, emptyList(), 0);
     }
 
-    public GitRepoSituation(boolean clean, String headCommit, String headBranch, List<String> headTags, Date headCommitDate) {
+    public GitRepoSituation(boolean clean, String headCommit, String headBranch, List<String> headTags, long headCommitTimestamp) {
         setClean(clean);
         setHeadCommit(headCommit);
         setHeadBranch(headBranch);
         setHeadTags(headTags);
-        setHeadCommitDate(headCommitDate);
+        setHeadCommitTimestamp(headCommitTimestamp);
     }
 
     public boolean isClean() {
@@ -62,13 +62,13 @@ public class GitRepoSituation {
         this.headTags = requireNonNull(headTags);
     }
 
-    public Date getHeadCommitDate()
+    public long getHeadCommitTimestamp()
     {
-        return headCommitDate;
+        return headCommitTimestamp;
     }
 
-    public void setHeadCommitDate(Date headCommitDate)
+    public void setHeadCommitTimestamp(long headCommitTimestamp)
     {
-        this.headCommitDate = headCommitDate;
+        this.headCommitTimestamp = headCommitTimestamp;
     }
 }

--- a/src/main/java/me/qoomon/gitversioning/GitRepoSituation.java
+++ b/src/main/java/me/qoomon/gitversioning/GitRepoSituation.java
@@ -1,5 +1,6 @@
 package me.qoomon.gitversioning;
 
+import java.util.Date;
 import java.util.List;
 
 import static java.util.Collections.emptyList;
@@ -11,17 +12,19 @@ public class GitRepoSituation {
     private boolean clean;
     private String headCommit;
     private String headBranch;
+    private Date headCommitDate;
     private List<String> headTags;
 
     public GitRepoSituation(){
-        this(true, NO_COMMIT, null, emptyList());
+        this(true, NO_COMMIT, null, emptyList(), null);
     }
 
-    public GitRepoSituation(boolean clean, String headCommit, String headBranch, List<String> headTags) {
+    public GitRepoSituation(boolean clean, String headCommit, String headBranch, List<String> headTags, Date headCommitDate) {
         setClean(clean);
         setHeadCommit(headCommit);
         setHeadBranch(headBranch);
         setHeadTags(headTags);
+        setHeadCommitDate(headCommitDate);
     }
 
     public boolean isClean() {
@@ -57,5 +60,15 @@ public class GitRepoSituation {
 
     public void setHeadTags(List<String> headTags) {
         this.headTags = requireNonNull(headTags);
+    }
+
+    public Date getHeadCommitDate()
+    {
+        return headCommitDate;
+    }
+
+    public void setHeadCommitDate(Date headCommitDate)
+    {
+        this.headCommitDate = headCommitDate;
     }
 }

--- a/src/main/java/me/qoomon/gitversioning/GitUtil.java
+++ b/src/main/java/me/qoomon/gitversioning/GitUtil.java
@@ -10,6 +10,7 @@ import org.eclipse.jgit.storage.file.FileRepositoryBuilder;
 import java.io.File;
 import java.util.Date;
 import java.util.List;
+import java.util.Optional;
 
 import static java.util.stream.Collectors.toList;
 import static me.qoomon.UncheckedExceptions.unchecked;
@@ -51,13 +52,13 @@ public final class GitUtil {
         return rev.getName();
     }
 
-    public static Date revDate(Repository repository, String revstr) {
+    public static Optional<Date> revDate(Repository repository, String revstr) {
         ObjectId rev = unchecked(() -> repository.resolve(revstr));
         if (rev == null) {
-            return null;
+            return Optional.empty();
         }
         PersonIdent authorIdent = unchecked(() -> repository.parseCommit(rev).getAuthorIdent());
-        return authorIdent.getWhen();
+        return Optional.of(authorIdent.getWhen());
     }
 
     public static GitRepoSituation situation(File directory) {
@@ -70,9 +71,9 @@ public final class GitUtil {
             boolean headClean = GitUtil.status(repository).isClean();
             String headCommit = GitUtil.revParse(repository, HEAD);
             String headBranch = GitUtil.branch(repository);
-            Date headCommitDate = GitUtil.revDate(repository, HEAD);
+            Optional<Date> headCommitDate = GitUtil.revDate(repository, HEAD);
             List<String> headTags = GitUtil.tag_pointsAt(repository, HEAD);
-            return new GitRepoSituation(headClean, headCommit, headBranch, headTags, headCommitDate);
+            return new GitRepoSituation(headClean, headCommit, headBranch, headTags, headCommitDate.orElse(null));
         }
     }
 }

--- a/src/main/java/me/qoomon/gitversioning/GitUtil.java
+++ b/src/main/java/me/qoomon/gitversioning/GitUtil.java
@@ -3,10 +3,12 @@ package me.qoomon.gitversioning;
 import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.api.Status;
 import org.eclipse.jgit.lib.ObjectId;
+import org.eclipse.jgit.lib.PersonIdent;
 import org.eclipse.jgit.lib.Repository;
 import org.eclipse.jgit.storage.file.FileRepositoryBuilder;
 
 import java.io.File;
+import java.util.Date;
 import java.util.List;
 
 import static java.util.stream.Collectors.toList;
@@ -49,6 +51,15 @@ public final class GitUtil {
         return rev.getName();
     }
 
+    public static Date revDate(Repository repository, String revstr) {
+        ObjectId rev = unchecked(() -> repository.resolve(revstr));
+        if (rev == null) {
+            return null;
+        }
+        PersonIdent authorIdent = unchecked(() -> repository.parseCommit(rev).getAuthorIdent());
+        return authorIdent.getWhen();
+    }
+
     public static GitRepoSituation situation(File directory) {
         FileRepositoryBuilder repositoryBuilder = new FileRepositoryBuilder().findGitDir(directory);
         if (repositoryBuilder.getGitDir() == null) {
@@ -59,8 +70,9 @@ public final class GitUtil {
             boolean headClean = GitUtil.status(repository).isClean();
             String headCommit = GitUtil.revParse(repository, HEAD);
             String headBranch = GitUtil.branch(repository);
+            Date headCommitDate = GitUtil.revDate(repository, HEAD);
             List<String> headTags = GitUtil.tag_pointsAt(repository, HEAD);
-            return new GitRepoSituation(headClean, headCommit, headBranch, headTags);
+            return new GitRepoSituation(headClean, headCommit, headBranch, headTags, headCommitDate);
         }
     }
 }

--- a/src/main/java/me/qoomon/gitversioning/GitUtil.java
+++ b/src/main/java/me/qoomon/gitversioning/GitUtil.java
@@ -3,14 +3,11 @@ package me.qoomon.gitversioning;
 import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.api.Status;
 import org.eclipse.jgit.lib.ObjectId;
-import org.eclipse.jgit.lib.PersonIdent;
 import org.eclipse.jgit.lib.Repository;
 import org.eclipse.jgit.storage.file.FileRepositoryBuilder;
 
 import java.io.File;
-import java.util.Date;
 import java.util.List;
-import java.util.Optional;
 
 import static java.util.stream.Collectors.toList;
 import static me.qoomon.UncheckedExceptions.unchecked;
@@ -52,13 +49,13 @@ public final class GitUtil {
         return rev.getName();
     }
 
-    public static Optional<Date> revDate(Repository repository, String revstr) {
+    public static long revTimestamp(Repository repository, String revstr) {
         ObjectId rev = unchecked(() -> repository.resolve(revstr));
         if (rev == null) {
-            return Optional.empty();
+            return 0;
         }
-        PersonIdent authorIdent = unchecked(() -> repository.parseCommit(rev).getAuthorIdent());
-        return Optional.of(authorIdent.getWhen());
+        // The timestamp is expressed in seconds since epoch...
+        return unchecked(() -> repository.parseCommit(rev).getCommitTime());
     }
 
     public static GitRepoSituation situation(File directory) {
@@ -71,9 +68,9 @@ public final class GitUtil {
             boolean headClean = GitUtil.status(repository).isClean();
             String headCommit = GitUtil.revParse(repository, HEAD);
             String headBranch = GitUtil.branch(repository);
-            Optional<Date> headCommitDate = GitUtil.revDate(repository, HEAD);
+            long headCommitTimestamp = GitUtil.revTimestamp(repository, HEAD);
             List<String> headTags = GitUtil.tag_pointsAt(repository, HEAD);
-            return new GitRepoSituation(headClean, headCommit, headBranch, headTags, headCommitDate.orElse(null));
+            return new GitRepoSituation(headClean, headCommit, headBranch, headTags, headCommitTimestamp);
         }
     }
 }

--- a/src/main/java/me/qoomon/gitversioning/GitVersioning.java
+++ b/src/main/java/me/qoomon/gitversioning/GitVersioning.java
@@ -3,6 +3,9 @@ package me.qoomon.gitversioning;
 import org.apache.maven.artifact.versioning.DefaultArtifactVersion;
 
 import javax.annotation.Nonnull;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -14,6 +17,8 @@ import static me.qoomon.gitversioning.StringUtil.substituteText;
 import static me.qoomon.gitversioning.StringUtil.valueGroupMap;
 
 public final class GitVersioning {
+
+    public static String VERSION_DATE_TIME_FORMAT = "yyyyMMdd.HHmmss";
 
     private GitVersioning() {
     }
@@ -69,6 +74,8 @@ public final class GitVersioning {
         projectVersionDataMap.put("version", currentVersion);
         projectVersionDataMap.put("version.release", currentVersion.replaceFirst("-SNAPSHOT$",""));
         projectVersionDataMap.put("commit", repoSituation.getHeadCommit());
+        projectVersionDataMap.put("timestamp", timestampOrEmpty(repoSituation.getHeadCommitDate()));
+        projectVersionDataMap.put("datetime", dateTimeOrEmpty(repoSituation.getHeadCommitDate()));
         projectVersionDataMap.put("commit.short", repoSituation.getHeadCommit().substring(0, 7));
         projectVersionDataMap.put("ref", gitRefName);
         projectVersionDataMap.put(gitRefType, gitRefName);
@@ -85,5 +92,22 @@ public final class GitVersioning {
                 refFields,
                 gitVersion
         );
+    }
+
+    private static String dateTimeOrEmpty(Date headCommitDate){
+        if (headCommitDate == null){
+            return "";
+        }
+        return DateTimeFormatter
+                .ofPattern(VERSION_DATE_TIME_FORMAT)
+                .withZone(ZoneOffset.UTC)
+                .format(headCommitDate.toInstant());
+    }
+
+    private static String timestampOrEmpty(Date headCommitDate){
+        if (headCommitDate == null){
+            return "";
+        }
+        return Long.toString(headCommitDate.getTime());
     }
 }

--- a/src/main/java/me/qoomon/gitversioning/GitVersioning.java
+++ b/src/main/java/me/qoomon/gitversioning/GitVersioning.java
@@ -3,9 +3,9 @@ package me.qoomon.gitversioning;
 import org.apache.maven.artifact.versioning.DefaultArtifactVersion;
 
 import javax.annotation.Nonnull;
+import java.time.Instant;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -18,7 +18,8 @@ import static me.qoomon.gitversioning.StringUtil.valueGroupMap;
 
 public final class GitVersioning {
 
-    public static String VERSION_DATE_TIME_FORMAT = "yyyyMMdd.HHmmss";
+    public static final String VERSION_DATE_TIME_FORMAT = "yyyyMMdd.HHmmss";
+    public static final String NO_COMMIT_DATE = "00000000.000000";
 
     private GitVersioning() {
     }
@@ -74,8 +75,8 @@ public final class GitVersioning {
         projectVersionDataMap.put("version", currentVersion);
         projectVersionDataMap.put("version.release", currentVersion.replaceFirst("-SNAPSHOT$",""));
         projectVersionDataMap.put("commit", repoSituation.getHeadCommit());
-        projectVersionDataMap.put("timestamp", timestampOrEmpty(repoSituation.getHeadCommitDate()));
-        projectVersionDataMap.put("datetime", dateTimeOrEmpty(repoSituation.getHeadCommitDate()));
+        projectVersionDataMap.put("commit.timestamp", Long.toString(repoSituation.getHeadCommitTimestamp()));
+        projectVersionDataMap.put("commit.datetime", formatHeadCommitTimestamp(repoSituation.getHeadCommitTimestamp()));
         projectVersionDataMap.put("commit.short", repoSituation.getHeadCommit().substring(0, 7));
         projectVersionDataMap.put("ref", gitRefName);
         projectVersionDataMap.put(gitRefType, gitRefName);
@@ -94,20 +95,14 @@ public final class GitVersioning {
         );
     }
 
-    private static String dateTimeOrEmpty(Date headCommitDate){
-        if (headCommitDate == null){
-            return "";
+    private static String formatHeadCommitTimestamp(long headCommitDate){
+        if (headCommitDate == 0){
+            return NO_COMMIT_DATE;
         }
         return DateTimeFormatter
                 .ofPattern(VERSION_DATE_TIME_FORMAT)
                 .withZone(ZoneOffset.UTC)
-                .format(headCommitDate.toInstant());
+                .format(Instant.ofEpochSecond(headCommitDate));
     }
 
-    private static String timestampOrEmpty(Date headCommitDate){
-        if (headCommitDate == null){
-            return "";
-        }
-        return Long.toString(headCommitDate.getTime());
-    }
 }

--- a/src/test/java/me/qoomon/gitversioning/GitVersioningTest.java
+++ b/src/test/java/me/qoomon/gitversioning/GitVersioningTest.java
@@ -121,12 +121,12 @@ class GitVersioningTest {
         GitRepoSituation repoSituation = new GitRepoSituation();
         repoSituation.setHeadBranch("develop");
         Instant instant = ZonedDateTime.of(2019, 4, 23, 10, 12, 45, 0, ZoneOffset.UTC).toInstant();
-        repoSituation.setHeadCommitDate(Date.from(instant));
+        repoSituation.setHeadCommitTimestamp(instant.getEpochSecond());
 
         // when
         GitVersionDetails gitVersionDetails = GitVersioning.determineVersion(repoSituation,
                 new VersionDescription(),
-                asList(new VersionDescription(null, "${timestamp}-branch")),
+                asList(new VersionDescription(null, "${commit.timestamp}-branch")),
                 emptyList(),
                 "undefined");
 
@@ -136,7 +136,7 @@ class GitVersioningTest {
             softly.assertThat(it.getCommit()).isEqualTo(repoSituation.getHeadCommit());
             softly.assertThat(it.getCommitRefType()).isEqualTo("branch");
             softly.assertThat(it.getCommitRefName()).isEqualTo(repoSituation.getHeadBranch());
-            softly.assertThat(it.getVersion()).isEqualTo(instant.toEpochMilli() + "-branch");
+            softly.assertThat(it.getVersion()).isEqualTo(instant.getEpochSecond() + "-branch");
         }));
     }
 
@@ -147,12 +147,12 @@ class GitVersioningTest {
         GitRepoSituation repoSituation = new GitRepoSituation();
         repoSituation.setHeadBranch("develop");
         Instant instant = ZonedDateTime.of(2019, 4, 23, 10, 12, 45, 0, ZoneOffset.UTC).toInstant();
-        repoSituation.setHeadCommitDate(Date.from(instant));
+        repoSituation.setHeadCommitTimestamp(instant.getEpochSecond());
 
         // when
         GitVersionDetails gitVersionDetails = GitVersioning.determineVersion(repoSituation,
                 new VersionDescription(),
-                asList(new VersionDescription(null, "${datetime}-branch")),
+                asList(new VersionDescription(null, "${commit.datetime}-branch")),
                 emptyList(),
                 "undefined");
 


### PR DESCRIPTION
Added support for commit date time to make the version sequential by using the placeholders 'datetime' or 'timestamp'. 
For example using the expression {datetime}-${commit.short} produces something like 20190521.011351-9abfd9d
Similarly, {timestamp}-${commit.short} produces 1558401231000-9abfd9d

Let me know if you like the additional feature or if you want me to change something.