### PR TITLE
Added flag to skip model processing

### DIFF
--- a/src/main/java/me/qoomon/maven/gitversioning/ModelProcessor.java
+++ b/src/main/java/me/qoomon/maven/gitversioning/ModelProcessor.java
@@ -59,6 +59,8 @@ import me.qoomon.gitversioning.VersionDescription;
 @Component(role = org.apache.maven.model.building.ModelProcessor.class)
 public class ModelProcessor extends DefaultModelProcessor {
 
+    private static final String SKIP_FLAG = "qoomon.gitversioning.skip";
+
     private final Logger logger;
 
     private final SessionScope sessionScope;
@@ -116,6 +118,11 @@ public class ModelProcessor extends DefaultModelProcessor {
                 return projectModel;
             }
 
+            if (shouldSkip()) {
+                logger.warn("skip - qoomon.gitversioning.skip property is set");
+                return projectModel;
+            }
+
             final Source pomSource = (Source) options.get(org.apache.maven.model.building.ModelProcessor.SOURCE);
             if (pomSource != null) {
                 projectModel.setPomFile(new File(pomSource.getLocation()));
@@ -125,6 +132,11 @@ public class ModelProcessor extends DefaultModelProcessor {
         } catch (Exception e) {
             throw new IOException("Git Versioning Model Processor", e);
         }
+    }
+
+    private boolean shouldSkip() {
+        return Boolean.parseBoolean(mavenSession.getSystemProperties().getProperty(SKIP_FLAG))
+                || Boolean.parseBoolean(mavenSession.getUserProperties().getProperty(SKIP_FLAG));
     }
 
     private Model processModel(Model projectModel) {


### PR DESCRIPTION
Hi Bengt

I'm Alex, from Jetbrains team. 

Our users have some issues with your plugin, please consider https://youtrack.jetbrains.com/issue/IDEA-220311

Actually,  there were  an issue in previous idea versions (https://youtrack.jetbrains.com/issue/IDEA-200272), when sessionScope was not entered, mavenSession was not set and maven-git-versioning-extension simply was not executed with message "skip - no maven session present".

Now, it is being executed and this lead to resolve issues during project import

At the moment, it is quite hard from our side to catch patched model "on-the-fly".

I believe there can be an option to disable extension execution using command line properties, e.g. the same way it is done in jitver-maven-plugin

It would greatly helps in operations which do not require versioning feature  and will provide a clear workaround for importing projects into idea.

I've attached a small PR, please consider this functionality.
