### PR TITLE
[FEATURE REQUEST] prefer tag rules over branch rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Create `${basedir}/.mvn/maven-git-versioning-extension.xml`.
 
 - *optional* `<updatePom>` global enable(`true`)/disable(`false`) version update in original pom file.
 
-- *optional* `<preferTags>` set `true` to prefer tag rules over branch rules if both match.
+- *optional* `<preferTags>` global enable(`true`)/disable(`false`) prefer tag rules over branch rules if both match.
 
 - `<branch>` specific version format definition.
     - `<pattern>` An arbitrary regex to match branch names (has to be a **full match pattern** e.g. `feature/.+` )

--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ Create `${basedir}/.mvn/maven-git-versioning-extension.xml`.
 
 - *optional* `<updatePom>` global enable(`true`)/disable(`false`) version update in original pom file.
 
+- *optional* `<preferTags>` set `true` to prefer tag rules over branch rules if both match.
+
 - `<branch>` specific version format definition.
     - `<pattern>` An arbitrary regex to match branch names (has to be a **full match pattern** e.g. `feature/.+` )
     - `<versionFormat>` An arbitrary string, see [Version Format & Placeholders](#version-format--placeholders)

--- a/README.md
+++ b/README.md
@@ -184,10 +184,14 @@ Create `${basedir}/.mvn/maven-git-versioning-extension.xml`.
         - `export VERSIONING_GIT_BRANCH=$PROVIDED_BRANCH_NAME`
         - `export VERSIONING_GIT_TAG=$PROVIDED_TAG_NAME`
         - `export VERSIONING_DISABLE=true`
+        - `export VERSIONING_PREFER_TAGS=true`
+        - `export VERSIONING_UPDATE_POM=true`
     - **Command Line Parameters**
         - `maven ... -Dgit.branch=$PROVIDED_BRANCH_NAME`
         - `maven ... -Dgit.tag=$PROVIDED_TAG_NAME`
         - `maven ... -Dversioning.disable=true`
+        - `maven ... -Dversioning.preferTags=true`
+        - `maven ... -Dversioning.updatePom=true`
   
   ℹ Especially useful for **CI builds** see [Miscellaneous Hints](#miscellaneous-hints)
 

--- a/src/main/java/me/qoomon/gitversioning/GitVersioning.java
+++ b/src/main/java/me/qoomon/gitversioning/GitVersioning.java
@@ -41,56 +41,24 @@ public final class GitVersioning {
         requireNonNull(branchVersionDescriptions);
         requireNonNull(tagVersionDescriptions);
 
-        // default versioning
-        String gitRefType = "commit";
-        String gitRefName = repoSituation.getHeadCommit();
-        VersionDescription versionDescription = commitVersionDescription;
+        final VersioningInfo versioningInfo = getVersioningInfo(repoSituation, commitVersionDescription, branchVersionDescriptions, tagVersionDescriptions);
 
-        if (repoSituation.getHeadBranch() != null) {
-            // branch versioning
-            for (final VersionDescription branchVersionDescription : branchVersionDescriptions) {
-                Optional<String> versionBranch = Optional.of(repoSituation.getHeadBranch())
-                        .filter(branch -> branch.matches(branchVersionDescription.getPattern()));
-                if (versionBranch.isPresent()) {
-                    gitRefType = "branch";
-                    gitRefName = versionBranch.get();
-                    versionDescription = branchVersionDescription;
-                    break;
-                }
-            }
-        } else if (!repoSituation.getHeadTags().isEmpty()) {
-            // tag versioning
-            for (final VersionDescription tagVersionDescription : tagVersionDescriptions) {
-                Optional<String> versionTag = repoSituation.getHeadTags().stream()
-                        .filter(tag -> tag.matches(tagVersionDescription.getPattern()))
-                        .max(comparing(DefaultArtifactVersion::new));
-                if (versionTag.isPresent()) {
-                    gitRefType = "tag";
-                    gitRefName = versionTag.get();
-                    versionDescription = tagVersionDescription;
-                    break;
-                }
-            }
-        }
-
-        final VersionDescription finalVersionDescription = versionDescription;
-
-        final Map<String, String> refData = valueGroupMap(versionDescription.getPattern(), gitRefName);
+        final Map<String, String> refData = valueGroupMap(versioningInfo.description.getPattern(), versioningInfo.gitRefName);
 
         final Map<String, String> gitDataMap = new HashMap<>();
         gitDataMap.put("commit", repoSituation.getHeadCommit());
         gitDataMap.put("commit.short", repoSituation.getHeadCommit().substring(0, 7));
         gitDataMap.put("commit.timestamp", Long.toString(repoSituation.getHeadCommitTimestamp()));
         gitDataMap.put("commit.timestamp.datetime", formatHeadCommitTimestamp(repoSituation.getHeadCommitTimestamp()));
-        gitDataMap.put("ref", gitRefName);
-        gitDataMap.put(gitRefType, gitRefName);
+        gitDataMap.put("ref", versioningInfo.gitRefName);
+        gitDataMap.put(versioningInfo.gitRefType, versioningInfo.gitRefName);
         gitDataMap.putAll(refData);
 
         final VersionTransformer versionTransformer = currentVersion -> {
             final Map<String, String> dataMap = new HashMap<>(gitDataMap);
             dataMap.put("version", currentVersion);
             dataMap.put("version.release", currentVersion.replaceFirst("-SNAPSHOT$", ""));
-            return substituteText(finalVersionDescription.getVersionFormat(), dataMap)
+            return substituteText(versioningInfo.description.getVersionFormat(), dataMap)
                     .replace("/", "-");
         };
 
@@ -99,17 +67,59 @@ public final class GitVersioning {
             dataMap.put("version", currentVersion);
             dataMap.put("version.release", currentVersion.replaceFirst("-SNAPSHOT$", ""));
             return transformProperties(
-                    currentProperties, finalVersionDescription.getPropertyDescriptions(), dataMap);
+                    currentProperties, versioningInfo.description.getPropertyDescriptions(), dataMap);
         };
 
         return new GitVersionDetails(
                 repoSituation.isClean(),
                 repoSituation.getHeadCommit(),
-                gitRefType,
-                gitRefName,
+                versioningInfo.gitRefType,
+                versioningInfo.gitRefName,
                 versionTransformer,
                 propertiesTransformer
         );
+    }
+
+    private static VersioningInfo getVersioningInfo(GitRepoSituation repoSituation, VersionDescription commitVersionDescription, List<VersionDescription> branchVersionDescriptions, List<VersionDescription> tagVersionDescriptions) {
+
+        // tags take precedence over branches
+        VersioningInfo versioningInfo = getTagVersioningInfo(repoSituation, tagVersionDescriptions);
+        if (versioningInfo == null) {
+            versioningInfo = getBranchVersioningInfo(repoSituation, branchVersionDescriptions);
+        }
+
+        // default versioning: commit
+        if (versioningInfo == null) {
+            versioningInfo = new VersioningInfo("commit", repoSituation.getHeadCommit(), commitVersionDescription);
+        }
+        return versioningInfo;
+    }
+
+    private static VersioningInfo getTagVersioningInfo(GitRepoSituation repoSituation, List<VersionDescription> tagVersionDescriptions) {
+        if (!repoSituation.getHeadTags().isEmpty()) {
+            for (final VersionDescription tagVersionDescription : tagVersionDescriptions) {
+                Optional<String> versionTag = repoSituation.getHeadTags().stream()
+                        .filter(tag -> tag.matches(tagVersionDescription.getPattern()))
+                        .max(comparing(DefaultArtifactVersion::new));
+                if (versionTag.isPresent()) {
+                    return new VersioningInfo("tag", versionTag.get(), tagVersionDescription);
+                }
+            }
+        }
+        return null;
+    }
+
+    private static VersioningInfo getBranchVersioningInfo(GitRepoSituation repoSituation, List<VersionDescription> branchVersionDescriptions) {
+        if (repoSituation.getHeadBranch() != null) {
+            for (final VersionDescription branchVersionDescription : branchVersionDescriptions) {
+                Optional<String> versionBranch = Optional.of(repoSituation.getHeadBranch())
+                        .filter(branch -> branch.matches(branchVersionDescription.getPattern()));
+                if (versionBranch.isPresent()) {
+                    return new VersioningInfo("branch", versionBranch.get(), branchVersionDescription);
+                }
+            }
+        }
+        return null;
     }
 
     private static Map<String, String> transformProperties(Map<String, String> currentProperties,
@@ -150,5 +160,17 @@ public final class GitVersioning {
                 .ofPattern(VERSION_DATE_TIME_FORMAT)
                 .withZone(ZoneOffset.UTC)
                 .format(Instant.ofEpochSecond(headCommitDate));
+    }
+
+    private static class VersioningInfo {
+        private final String gitRefType;
+        private final String gitRefName;
+        private final VersionDescription description;
+
+        private VersioningInfo(String gitRefType, String gitRefName, VersionDescription versionDescription) {
+            this.gitRefType = gitRefType;
+            this.gitRefName = gitRefName;
+            this.description = versionDescription;
+        }
     }
 }

--- a/src/main/java/me/qoomon/gitversioning/GitVersioning.java
+++ b/src/main/java/me/qoomon/gitversioning/GitVersioning.java
@@ -91,7 +91,7 @@ public final class GitVersioning {
         if (versioningInfo == null) {
             versioningInfo = getBranchVersioningInfo(repoSituation, branchVersionDescriptions);
         }
-        if (!preferTags && versioningInfo == null) {
+        if (versioningInfo == null && !preferTags) {
             versioningInfo = getTagVersioningInfo(repoSituation, tagVersionDescriptions);
         }
 

--- a/src/main/java/me/qoomon/maven/gitversioning/GitVersioningModelProcessor.java
+++ b/src/main/java/me/qoomon/maven/gitversioning/GitVersioningModelProcessor.java
@@ -30,7 +30,6 @@ import java.util.regex.Pattern;
 
 import javax.inject.Inject;
 
-import com.google.common.base.CaseFormat;
 import org.apache.maven.building.Source;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.model.Build;

--- a/src/test/java/me/qoomon/gitversioning/GitVersioningTest.java
+++ b/src/test/java/me/qoomon/gitversioning/GitVersioningTest.java
@@ -118,6 +118,34 @@ class GitVersioningTest {
     }
 
     @Test
+    void determineVersion_forBranchWithTag_withTagRule() {
+
+        // given
+        GitRepoSituation repoSituation = new GitRepoSituation();
+        repoSituation.setHeadBranch("develop");
+        repoSituation.setHeadTags(singletonList("v1"));
+
+        String currentVersion = "undefined";
+
+        // when
+        GitVersionDetails gitVersionDetails = GitVersioning.determineVersion(repoSituation,
+                new VersionDescription(),
+                singletonList(new VersionDescription(null, "${branch}-branch")),
+                singletonList(new VersionDescription(null, "${tag}-tag")));
+
+        String gitVersion = gitVersionDetails.getVersionTransformer().apply(currentVersion);
+
+        // then
+        assertAll(
+                () -> assertThat(gitVersionDetails.isClean()).isTrue(),
+                () -> assertThat(gitVersionDetails.getCommit()).isEqualTo(repoSituation.getHeadCommit()),
+                () -> assertThat(gitVersionDetails.getCommitRefType()).isEqualTo("tag"),
+                () -> assertThat(gitVersionDetails.getCommitRefName()).isEqualTo(repoSituation.getHeadTags().get(0)),
+                () -> assertThat(gitVersion).isEqualTo(repoSituation.getHeadTags().get(0) + "-tag")
+        );
+    }
+
+    @Test
     void determineVersion_detachedHead() {
 
         // given


### PR DESCRIPTION
Currently, tag rules are omitted if there is a branch available. This does not really make sense, as one hardly ever checks out a specific tag to create a build. I suggest to prefer the tag if there is a matching tag rule.

BTW, thank you for this great tool!