### PR TITLE
fix (?): cli option should override config file

### DIFF
--- a/src/main/java/me/qoomon/maven/gitversioning/GitVersioningModelProcessor.java
+++ b/src/main/java/me/qoomon/maven/gitversioning/GitVersioningModelProcessor.java
@@ -1,18 +1,24 @@
 package me.qoomon.maven.gitversioning;
 
-import com.fasterxml.jackson.dataformat.xml.XmlMapper;
-import com.google.common.collect.Maps;
-import com.google.inject.Key;
-import com.google.inject.OutOfScopeException;
-import me.qoomon.gitversioning.*;
-import org.apache.maven.building.Source;
-import org.apache.maven.execution.MavenSession;
-import org.apache.maven.model.*;
-import org.apache.maven.session.scope.internal.SessionScope;
-import org.codehaus.plexus.logging.Logger;
-import org.eclipse.jgit.storage.file.FileRepositoryBuilder;
+import static java.lang.Boolean.parseBoolean;
+import static java.lang.Math.ceil;
+import static java.lang.Math.floor;
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
+import static java.util.Optional.ofNullable;
+import static java.util.stream.Collectors.toList;
 
-import javax.inject.Inject;
+import static me.qoomon.UncheckedExceptions.unchecked;
+import static me.qoomon.maven.gitversioning.MavenUtil.isProjectPom;
+import static me.qoomon.maven.gitversioning.MavenUtil.readModel;
+import static me.qoomon.maven.gitversioning.VersioningMojo.GIT_VERSIONING_POM_NAME;
+import static me.qoomon.maven.gitversioning.VersioningMojo.GOAL;
+import static me.qoomon.maven.gitversioning.VersioningMojo.asPlugin;
+import static me.qoomon.maven.gitversioning.VersioningMojo.propertyKeyPrefix;
+import static me.qoomon.maven.gitversioning.VersioningMojo.propertyKeyUpdatePom;
+import static org.apache.maven.shared.utils.StringUtils.repeat;
+import static org.apache.maven.shared.utils.logging.MessageUtils.buffer;
+
 import java.io.File;
 import java.io.IOException;
 import java.util.HashMap;
@@ -22,19 +28,31 @@ import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.regex.Pattern;
 
-import static java.lang.Boolean.parseBoolean;
-import static java.lang.Math.ceil;
-import static java.lang.Math.floor;
-import static java.util.Collections.emptyList;
-import static java.util.Collections.singletonList;
-import static java.util.Optional.ofNullable;
-import static java.util.stream.Collectors.toList;
-import static me.qoomon.UncheckedExceptions.unchecked;
-import static me.qoomon.maven.gitversioning.MavenUtil.isProjectPom;
-import static me.qoomon.maven.gitversioning.MavenUtil.readModel;
-import static me.qoomon.maven.gitversioning.VersioningMojo.*;
-import static org.apache.maven.shared.utils.StringUtils.repeat;
-import static org.apache.maven.shared.utils.logging.MessageUtils.buffer;
+import javax.inject.Inject;
+
+import org.apache.maven.building.Source;
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.model.Build;
+import org.apache.maven.model.Model;
+import org.apache.maven.model.Parent;
+import org.apache.maven.model.Plugin;
+import org.apache.maven.model.PluginExecution;
+import org.apache.maven.session.scope.internal.SessionScope;
+import org.codehaus.plexus.logging.Logger;
+import org.eclipse.jgit.storage.file.FileRepositoryBuilder;
+
+import com.fasterxml.jackson.dataformat.xml.XmlMapper;
+import com.google.common.collect.Maps;
+import com.google.inject.Key;
+import com.google.inject.OutOfScopeException;
+
+import me.qoomon.gitversioning.GitRepoSituation;
+import me.qoomon.gitversioning.GitUtil;
+import me.qoomon.gitversioning.GitVersionDetails;
+import me.qoomon.gitversioning.GitVersioning;
+import me.qoomon.gitversioning.PropertyDescription;
+import me.qoomon.gitversioning.PropertyValueDescription;
+import me.qoomon.gitversioning.VersionDescription;
 
 /**
  * WORKAROUND


### PR DESCRIPTION
Sorry to bother you again. I think the cli option `-Dversioning.preferTags=false` should override an
existing config option `<preferTags>true</preferTags>`, as similar behaviour can be observed if you set a tag or branch by cli option, causing existing branches and tags to be ignored.