### PR TITLE
Reduce log level to info

### DIFF
--- a/src/main/java/me/qoomon/maven/gitversioning/GitVersioningModelProcessor.java
+++ b/src/main/java/me/qoomon/maven/gitversioning/GitVersioningModelProcessor.java
@@ -105,7 +105,7 @@ public class GitVersioningModelProcessor {
                 }
 
                 if (parseBoolean(getCommandOption(OPTION_NAME_DISABLE))) {
-                    logger.warn("versioning is disabled");
+                    logger.info("versioning is disabled");
                     disabled = true;
                     return projectModel;
                 }


### PR DESCRIPTION
To align behavior to other maven plugins that use info level when skipping is enabled. And to get a warning free build.