### PR TITLE
don't error out on non-existant Git directories

### DIFF
--- a/src/main/java/me/qoomon/maven/gitversioning/GitVersioningModelProcessor.java
+++ b/src/main/java/me/qoomon/maven/gitversioning/GitVersioningModelProcessor.java
@@ -128,10 +128,14 @@ public class GitVersioningModelProcessor {
                 logger.debug("configFile: " + configFile.toString());
                 config = loadConfig(configFile);
 
-                gitDirectory = findGitDir(executionRootDirectory);
-                logger.debug("gitDirectory: " + gitDirectory.toString());
+                try {
+                    gitDirectory = findGitDir(executionRootDirectory);
+                    logger.debug("gitDirectory: " + gitDirectory.toString());
 
-                gitVersionDetails = getGitVersionDetails(config, executionRootDirectory);
+                    gitVersionDetails = getGitVersionDetails(config, executionRootDirectory);
+                } catch (FileNotFoundException e) {
+                    logger.warn(e.getMessage());
+                }
 
                 logger.info("Adjusting project models...");
                 logger.info("");
@@ -358,7 +362,7 @@ public class GitVersioningModelProcessor {
      * @return true if <code>pomFile</code> is part of a project
      */
     private boolean isRelatedPom(File pomFile) throws IOException {
-        return pomFile != null
+        return pomFile != null && gitDirectory != null
                 && pomFile.exists()
                 && pomFile.isFile()
                 // only project pom files ends in .xml, pom files from dependencies from repositories ends in .pom
@@ -370,7 +374,7 @@ public class GitVersioningModelProcessor {
 
     private static File findGitDir(File baseDirectory) throws FileNotFoundException {
         File gitDir = new FileRepositoryBuilder().findGitDir(baseDirectory).getGitDir();
-        if (!gitDir.exists()) {
+        if (gitDir == null || !gitDir.exists()) {
             throw new FileNotFoundException("Can not find .git directory in hierarchy of " + baseDirectory);
         }
         return gitDir;

--- a/src/test/java/me/qoomon/maven/gitversioning/GitVersioningExtensionIT.java
+++ b/src/test/java/me/qoomon/maven/gitversioning/GitVersioningExtensionIT.java
@@ -109,6 +109,28 @@ class GitVersioningExtensionIT {
     }
 
     @Test
+    void outsideGitVersioning() throws Exception {
+        // Given
+
+        writeModel(projectDir.resolve("pom.xml").toFile(), pomModel);
+        writeExtensionsFile(projectDir);
+        writeExtensionConfigFile(projectDir, new Configuration());
+
+        // When
+        Verifier verifier = new Verifier(projectDir.toFile().getAbsolutePath());
+        verifier.executeGoal("verify");
+
+        // Then
+        String log = getLog(verifier);
+        assertThat(log).doesNotContain("[ERROR]", "[FATAL]");
+        String expectedVersion = "0.0.0";
+        assertThat(log).contains("Building " + pomModel.getArtifactId() + " " + expectedVersion);
+
+        assertThat(projectDir.resolve("target/").resolve(GIT_VERSIONING_POM_NAME).toFile().exists()).isEqualTo(false);
+        assertThat(log).contains("[WARNING] Can not find .git directory in hierarchy of " + projectDir.toRealPath());
+    }
+
+    @Test
     void tagVersioning_annotated_detached() throws Exception {
         // Given
         Git git = Git.init().setDirectory(projectDir.toFile()).call();

--- a/src/test/java/me/qoomon/maven/gitversioning/GitVersioningExtensionIT.java
+++ b/src/test/java/me/qoomon/maven/gitversioning/GitVersioningExtensionIT.java
@@ -127,7 +127,7 @@ class GitVersioningExtensionIT {
         assertThat(log).contains("Building " + pomModel.getArtifactId() + " " + expectedVersion);
 
         assertThat(projectDir.resolve("target/").resolve(GIT_VERSIONING_POM_NAME).toFile().exists()).isEqualTo(false);
-        assertThat(log).contains("[WARNING] Can not find .git directory in hierarchy of " + projectDir.toRealPath());
+        assertThat(log).contains("[WARNING] skip - project is not part of a git repository");
     }
 
     @Test


### PR DESCRIPTION
This allows the build to succeed without a Git repository, but with a warning.