### PR TITLE
Make 'minute' and 'second' singular instead of plural in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,11 +156,11 @@ Create `${rootProjectDir}/.mvn/maven-git-versioning-extension.xml`.
 - `${commit.timestamp.hour}`
     - The `HEAD` commit hour of day (24h)
     - e.g. '01'
-- `${commit.timestamp.minutes}`
-    - The `HEAD` commit minutes of hour
+- `${commit.timestamp.minute}`
+    - The `HEAD` commit minute of hour
     - e.g. '01'
-- `${commit.timestamp.seconds}`
-    - The `HEAD` commit seconds of minute
+- `${commit.timestamp.second}`
+    - The `HEAD` commit second of minute
     - e.g. '01'
 - `${commit.timestamp.datetime}`
     - The `HEAD` commit timestamp formatted as `yyyyMMdd.HHmmss`


### PR DESCRIPTION
I noticed that the placeholders for minute and second are singular in the [code](https://github.com/qoomon/maven-git-versioning-extension/blob/e4adc7ab1e454ebe92aaee18c9c1b877c59f40b9/src/main/java/me/qoomon/maven/gitversioning/GitVersioningModelProcessor.java#L553) (equivalent to the ones for year, month, day and hour) but are (I assume accidentally) documented as being plural in the README.

A very minor thing but it cost me a couple of minutes so having this corrected may save someone else the time :slightly_smiling_face: 