### PR TITLE
Added a random number generator for offline builds

### DIFF
--- a/src/main/java/me/qoomon/gitversioning/commons/RandomNumberSupplier.java
+++ b/src/main/java/me/qoomon/gitversioning/commons/RandomNumberSupplier.java
@@ -1,0 +1,40 @@
+package me.qoomon.gitversioning.commons;
+
+import java.security.SecureRandom;
+import java.util.function.Supplier;
+
+public class RandomNumberSupplier {
+  private final SecureRandom generator;
+
+  public RandomNumberSupplier() {
+    this(new SecureRandom());
+  }
+
+  RandomNumberSupplier(final SecureRandom generator) {
+    this.generator = generator;
+  }
+
+  public Supplier<String> randomFourDigits() {
+    return this::fourDigits;
+  }
+
+  public Supplier<String> randomFiveDigits() {
+    return this::fiveDigits;
+  }
+
+  public Supplier<String> randomSixDigits() {
+    return this::sixDigits;
+  }
+
+  private String fourDigits() {
+    return String.format("%04d", generator.nextInt(10000));
+  }
+
+  private String fiveDigits() {
+    return String.format("%05d", generator.nextInt(100000));
+  }
+
+  private String sixDigits() {
+    return String.format("%06d", generator.nextInt(1000000));
+  }
+}

--- a/src/main/java/me/qoomon/maven/gitversioning/GitVersioningModelProcessor.java
+++ b/src/main/java/me/qoomon/maven/gitversioning/GitVersioningModelProcessor.java
@@ -8,6 +8,7 @@ import de.pdark.decentxml.Element;
 import me.qoomon.gitversioning.commons.GitDescription;
 import me.qoomon.gitversioning.commons.GitSituation;
 import me.qoomon.gitversioning.commons.Lazy;
+import me.qoomon.gitversioning.commons.RandomNumberSupplier;
 import me.qoomon.maven.gitversioning.Configuration.PatchDescription;
 import me.qoomon.maven.gitversioning.Configuration.RefPatchDescription;
 import org.apache.maven.artifact.versioning.DefaultArtifactVersion;
@@ -37,7 +38,6 @@ import java.util.function.Supplier;
 import java.util.regex.Pattern;
 
 import static com.fasterxml.jackson.databind.MapperFeature.ACCEPT_CASE_INSENSITIVE_ENUMS;
-import static com.fasterxml.jackson.databind.MapperFeature.USE_ANNOTATIONS;
 import static java.lang.Boolean.parseBoolean;
 import static java.lang.Math.*;
 import static java.time.format.DateTimeFormatter.ISO_INSTANT;
@@ -94,11 +94,11 @@ public class GitVersioningModelProcessor extends DefaultModelProcessor {
     private Map<String, String> gitProjectProperties;
     private Set<GAV> relatedProjects;
 
+    private final RandomNumberSupplier randomSupplier = new RandomNumberSupplier();
 
     // ---- other fields -----------------------------------------------------------------------------------------------
 
     private final Map<File, Model> sessionModelCache = new HashMap<>();
-
 
     @Override
     public Model read(File input, Map<String, ?> options) throws IOException {
@@ -117,7 +117,6 @@ public class GitVersioningModelProcessor extends DefaultModelProcessor {
         // clone model before return to prevent concurrency issues
         return processModel(super.read(input, options), options).clone();
     }
-
 
     private void init(Model projectModel) throws IOException {
         logger.info("");
@@ -774,6 +773,11 @@ public class GitVersioningModelProcessor extends DefaultModelProcessor {
 
         // environment variables e.g. BUILD_NUMBER=123 will be available as ${env.BUILD_NUMBER}
         System.getenv().forEach((key, value) -> placeholderMap.put("env." + key, () -> value));
+
+        // Add a four-digit numbers
+        placeholderMap.put("random.fourDigits", randomSupplier.randomFourDigits());
+        placeholderMap.put("random.fiveDigits", randomSupplier.randomFiveDigits());
+        placeholderMap.put("random.sixDigits", randomSupplier.randomSixDigits());
 
         return placeholderMap;
     }


### PR DESCRIPTION
For building a nearly unique version on dirty branches, I've added a random number generator that can build formatted build numbers of 4-, 5- or 6-digit wide random numbers.

They are stored in the variables `random.fourDigits`, `random.fiveDigits` and `random.sixDigits`.

You can use it like that:

```XML
<configuration xmlns="https://github.com/qoomon/maven-git-versioning-extension" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://github.com/qoomon/maven-git-versioning-extension https://qoomon.github.io/maven-git-versioning-extension/configuration-7.0.0.xsd">

    ...

    <refs>
        <ref type="branch">
            <pattern><![CDATA[(?<feature>.+)]]></pattern>
            <version>${version}.${random.sixDigits}-${ref}${dirty.snapshot}</version>
        </ref>
    </refs>

    ...

</configuration>
```

Then you get the version like that:

```
mvn help:evaluate -Dexpression=project.version -q -DforceStdout
0.0.1.554812-feature-heinz-SNAPSHOT
```

Maybe it is of some worth for you.

P.S. If you like, I can add tests for it. The package private constructor is designed as such and can e.g. take a mock object for repeatable tests and results.