### PR TITLE
Support disabling versioning for a subset of the modules in a multimodule project

### DIFF
--- a/src/main/java/me/qoomon/maven/gitversioning/Configuration.java
+++ b/src/main/java/me/qoomon/maven/gitversioning/Configuration.java
@@ -41,6 +41,11 @@ public class Configuration {
     @JsonProperty(required = true)
     public List<RelatedProject> relatedProjects = new ArrayList<>();
 
+    @JsonInclude(NON_EMPTY)
+    @JacksonXmlElementWrapper
+    @JsonProperty(required = true)
+    public List<RelatedProject> disabledProjects = new ArrayList<>();
+
     @JsonInclude(NON_NULL)
     public static class PatchDescription {
 


### PR DESCRIPTION
## Description

In a multimodule project the `maven-git-versioning-extension` applies either to all modules or to none of them.

## Change

This PR introduces a way to disable versioning for a subset of the modules in a multimodule project. The added configuration is similar to the existing `relatedProjects` config.

```xml
    ...
    <disabledProjects>
        <project>
            <groupId>me.qoomon</groupId>
            <artifactId>base</artifactId>
        </project>
    </disabledProjects>
```

Even if versioning is disabled for a module, the dependencies and parent of that module still has to be updated.

## Alternatives

Anotehr option would be to read the `versioning.disable` property in each project, and disable versioning based on that. A problem with that is if you want to enable versioning only in CI you would pass `-Dversioning.disable=false` from the command line, thereby enabling on all projects, not only the subset which is supposed to be versioned.
