### PR TITLE
additional version component placeholders

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ e.g `${dirty:-SNAPSHOT}` resolves to `-SNAPSHOT` instead of `-DIRTY`
 - `${version.release}` like `${version}` without `-SNAPSHOT` postfix e.g. '1.0.0'
 - `${version.major}` like `${version}` but only the major version component e.g. '1'
 - `${version.minor}` like `${version}` but only the minor version component e.g. '0'
+- `${version.patch}` like `${version}` but only the patch version component e.g. '0'
       <br><br>
 
 - `${ref}` `${ref.slug}` ref name (branch or tag name or commit hash)

--- a/README.md
+++ b/README.md
@@ -146,11 +146,11 @@ e.g `${dirty:-SNAPSHOT}` resolves to `-SNAPSHOT` instead of `-DIRTY`
 - `${property.name}` Value of commandline property `-Dname=value`
       <br><br>
 
-- `${version}` `<version>` set in `pom.xml` e.g. '1.0.0-SNAPSHOT'
-- `${version.release}` like `${version}` without `-SNAPSHOT` postfix e.g. '1.0.0'
-- `${version.major}` like `${version}` but only the major version component e.g. '1'
-- `${version.minor}` like `${version}` but only the minor version component e.g. '0'
-- `${version.patch}` like `${version}` but only the patch version component e.g. '0'
+- `${version}` `<version>` set in `pom.xml` e.g. '1.2.3-SNAPSHOT'
+- `${version.major}` the major version component of `${version}` e.g. '1'
+- `${version.minor}` the minor version component of `${version}` e.g. '2'
+- `${version.patch}` the patch version component of `${version}` e.g. '3'
+- `${version.release}` like `${version}` without `-SNAPSHOT` postfix e.g. '1.2.3'
       <br><br>
 
 - `${ref}` `${ref.slug}` ref name (branch or tag name or commit hash)

--- a/README.md
+++ b/README.md
@@ -148,6 +148,8 @@ e.g `${dirty:-SNAPSHOT}` resolves to `-SNAPSHOT` instead of `-DIRTY`
 
 - `${version}` `<version>` set in `pom.xml` e.g. '1.0.0-SNAPSHOT'
 - `${version.release}` like `${version}` without `-SNAPSHOT` postfix e.g. '1.0.0'
+- `${version.major}` like `${version}` but only the major version component e.g. '1'
+- `${version.minor}` like `${version}` but only the minor version component e.g. '0'
       <br><br>
 
 - `${ref}` `${ref.slug}` ref name (branch or tag name or commit hash)

--- a/src/main/java/me/qoomon/maven/gitversioning/GitVersioningModelProcessor.java
+++ b/src/main/java/me/qoomon/maven/gitversioning/GitVersioningModelProcessor.java
@@ -706,8 +706,8 @@ public class GitVersioningModelProcessor extends DefaultModelProcessor {
         placeholderMap.put("version.release", Lazy.by(() -> originalProjectVersion.get().replaceFirst("-SNAPSHOT$", "")));
 
         String[] versionComponents = originalProjectVersion.get().replaceFirst("-.*$","").split(".");
-        placeholderMap.put("version.major", Lazy.by(() -> versionComponents.length == 1 ? versionComponents[0] : ""));
-        placeholderMap.put("version.minor", Lazy.by(() -> versionComponents.length == 2 ? versionComponents[1] : ""));
+        placeholderMap.put("version.major", Lazy.by(() -> versionComponents.length >= 1 ? versionComponents[0] : ""));
+        placeholderMap.put("version.minor", Lazy.by(() -> versionComponents.length >= 2 ? versionComponents[1] : ""));
 
         return placeholderMap;
     }

--- a/src/main/java/me/qoomon/maven/gitversioning/GitVersioningModelProcessor.java
+++ b/src/main/java/me/qoomon/maven/gitversioning/GitVersioningModelProcessor.java
@@ -703,8 +703,12 @@ public class GitVersioningModelProcessor extends DefaultModelProcessor {
         final Map<String, Supplier<String>> placeholderMap = new HashMap<>(globalFormatPlaceholderMap);
         final Supplier<String> originalProjectVersion = originalProjectGAV::getVersion;
         placeholderMap.put("version", originalProjectVersion);
-        placeholderMap.put("version.release", Lazy.by(
-                () -> originalProjectVersion.get().replaceFirst("-SNAPSHOT$", "")));
+        placeholderMap.put("version.release", Lazy.by(() -> originalProjectVersion.get().replaceFirst("-SNAPSHOT$", "")));
+
+        String[] versionComponents = originalProjectVersion.get().replaceFirst("-.*$","").split(".");
+        placeholderMap.put("version.major", Lazy.by(() -> versionComponents.length == 1 ? versionComponents[0] : ""));
+        placeholderMap.put("version.minor", Lazy.by(() -> versionComponents.length == 2 ? versionComponents[1] : ""));
+
         return placeholderMap;
     }
 

--- a/src/main/java/me/qoomon/maven/gitversioning/GitVersioningModelProcessor.java
+++ b/src/main/java/me/qoomon/maven/gitversioning/GitVersioningModelProcessor.java
@@ -706,9 +706,9 @@ public class GitVersioningModelProcessor extends DefaultModelProcessor {
         placeholderMap.put("version.release", Lazy.by(() -> originalProjectVersion.get().replaceFirst("-SNAPSHOT$", "")));
 
         String[] versionComponents = originalProjectVersion.get().replaceFirst("-.*$","").split("\\.");
-        placeholderMap.put("version.major", Lazy.by(() -> versionComponents.length >= 1 ? versionComponents[0] : ""));
-        placeholderMap.put("version.minor", Lazy.by(() -> versionComponents.length >= 2 ? versionComponents[1] : ""));
-        placeholderMap.put("version.patch", Lazy.by(() -> versionComponents.length >= 3 ? versionComponents[2] : ""));
+        placeholderMap.put("version.major", Lazy.by(() -> versionComponents.length > 0 ? versionComponents[0] : ""));
+        placeholderMap.put("version.minor", Lazy.by(() -> versionComponents.length > 1 ? versionComponents[1] : ""));
+        placeholderMap.put("version.patch", Lazy.by(() -> versionComponents.length > 1 ? versionComponents[2] : ""));
 
         return placeholderMap;
     }

--- a/src/main/java/me/qoomon/maven/gitversioning/GitVersioningModelProcessor.java
+++ b/src/main/java/me/qoomon/maven/gitversioning/GitVersioningModelProcessor.java
@@ -705,7 +705,7 @@ public class GitVersioningModelProcessor extends DefaultModelProcessor {
         placeholderMap.put("version", originalProjectVersion);
         placeholderMap.put("version.release", Lazy.by(() -> originalProjectVersion.get().replaceFirst("-SNAPSHOT$", "")));
 
-        String[] versionComponents = originalProjectVersion.get().replaceFirst("-.*$","").split(".");
+        String[] versionComponents = originalProjectVersion.get().replaceFirst("-.*$","").split("\\.");
         placeholderMap.put("version.major", Lazy.by(() -> versionComponents.length >= 1 ? versionComponents[0] : ""));
         placeholderMap.put("version.minor", Lazy.by(() -> versionComponents.length >= 2 ? versionComponents[1] : ""));
         placeholderMap.put("version.patch", Lazy.by(() -> versionComponents.length >= 3 ? versionComponents[2] : ""));

--- a/src/main/java/me/qoomon/maven/gitversioning/GitVersioningModelProcessor.java
+++ b/src/main/java/me/qoomon/maven/gitversioning/GitVersioningModelProcessor.java
@@ -708,6 +708,7 @@ public class GitVersioningModelProcessor extends DefaultModelProcessor {
         String[] versionComponents = originalProjectVersion.get().replaceFirst("-.*$","").split(".");
         placeholderMap.put("version.major", Lazy.by(() -> versionComponents.length >= 1 ? versionComponents[0] : ""));
         placeholderMap.put("version.minor", Lazy.by(() -> versionComponents.length >= 2 ? versionComponents[1] : ""));
+        placeholderMap.put("version.patch", Lazy.by(() -> versionComponents.length >= 3 ? versionComponents[2] : ""));
 
         return placeholderMap;
     }


### PR DESCRIPTION
Having access to the main version components (i.e. major, minor as well as patch version), would allow us to use this extension in a setup with Tycho modules and their rather strict versioning scheme.