### PR TITLE
set ${version.*.next} placeholders properly

### DIFF
--- a/src/main/java/me/qoomon/maven/gitversioning/GitVersioningModelProcessor.java
+++ b/src/main/java/me/qoomon/maven/gitversioning/GitVersioningModelProcessor.java
@@ -727,7 +727,7 @@ public class GitVersioningModelProcessor extends DefaultModelProcessor {
         placeholderMap.put("version.major.next", Lazy.by(() -> increaseStringNumber(placeholderMap.get("version.major").get())));
 
         placeholderMap.put("version.minor", Lazy.by(() -> requireNonNullElse(versionComponents.get().group("minor"), "0")));
-        placeholderMap.put("version.major.next", Lazy.by(() -> increaseStringNumber(placeholderMap.get("version.minor").get())));
+        placeholderMap.put("version.minor.next", Lazy.by(() -> increaseStringNumber(placeholderMap.get("version.minor").get())));
 
         placeholderMap.put("version.patch", Lazy.by(() -> requireNonNullElse(versionComponents.get().group("patch"), "0")));
         placeholderMap.put("version.patch.next", Lazy.by(() -> increaseStringNumber(placeholderMap.get("version.patch").get())));


### PR DESCRIPTION
The `${version.major.next}` placeholder was redefined instead of setting `${version.minor.next}`.