### PR TITLE
Provide more fine grained ${version.*.label*} placeholders

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,10 @@ e.g `${dirty:-SNAPSHOT}` resolves to `-SNAPSHOT` instead of `-DIRTY`
     - `${version.patch.next}` the `${version.patch}` increased by 1 e.g. '4'
   - `${version.label}` the version label of `${version}` e.g. 'SNAPSHOT'
     - `${version.label.prefixed}` like `${version.label}` with label separator e.g. '-SNAPSHOT'
+  - `${version.release.label}` the version label of `${version}` with the snapshot suffix removed e.g. 'java7'
+    - `${version.release.label.prefixed}` like `${version.release.label}` with label separator e.g. '-java7'
+  - `${version.snapshot.label}` the snapshot suffix of `${version}` (if any) e.g. 'snapshot'
+    - `${version.snapshot.label.prefixed}` like `${version.snapshot.label}` with label separator e.g. '-snapshot'
   - `${version.release}` like `${version}` without version labels like `-SNAPSHOT` e.g. '1.2.3'
         <br><br>
 


### PR DESCRIPTION
## Description
Sometimes there is a need to wedge the git branch/tag information between an already present version label and possible `‑SNAPSHOT` suffix. In order to do that conveniently we'd need the label to be parsed into two parts:
- the part of label before the `-SNAPSHOT` suffix
- the `-SNAPSHOT` suffix of the label

#### Change
This PR introduces four new version label placeholders to assist in the situation described above:
- `${version.release.label}` - provides the version label with the snapshot suffix removed, if there is no snapshot suffix then this placeholder is identical to the `${version.label}` placeholder
- `${version.release.label.prefixed}` - prefixed version of the `${version.release.label}` placeholder
- `${version.snapshot.label}` - provides the version's snapshot suffix or an empty string if there is no snapshot suffix
- `${version.snapshot.label.prefixed}` - prefixed version of the `${version.snapshot.label}` placeholder

#### Examples
| Original&nbsp;version | ${version.release.label} | ${version.release.label.prefixed} | ${version.snapshot.label} | ${version.snapshot.label.prefixed} |
| ---- | ---- | ---- | ---- | ---- |
| `1.0.0‑java7‑SNAPSHOT` | `java7` | `‑java7` | `SNAPSHOT` | `‑SNAPSHOT` |
| `1.0.0‑java7` | `java7` | `‑java7` | (empty string) | (empty string) |
| `1.0.0‑SNAPSHOT` | (empty string) | (empty string) | `SNAPSHOT` | `‑SNAPSHOT` |
| `1.0.0` | (empty string) | (empty string) | (empty string) | (empty string) |