### PR TITLE
Provide maven-build-timestamp as "commit.timestamp"-like placeholder "build.timestamp" 

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,17 @@ e.g `${dirty:-SNAPSHOT}` resolves to `-SNAPSHOT` instead of `-DIRTY`
 - `${commit.timestamp.datetime}` commit timestamp formatted as `yyyyMMdd.HHmmss`e.g. '20190616.161442'
       <br><br>
 
+- `${build.timestamp}` maven-build-timestamp (epoch seconds) e.g. '1560694278'
+- `${build.timestamp.year}` maven-build-timestamp year e.g. '2021'
+- `${build.timestamp.year.2digit}` 2-digit maven-build-timestamp year.g. '21'
+- `${build.timestamp.month}` maven-build-timestamp month of year e.g. '12'
+- `${build.timestamp.day}` maven-build-timestamp day of month e.g. '23'
+- `${build.timestamp.hour}` maven-build-timestamp hour of day (24h)e.g. '13'
+- `${build.timestamp.minute}` maven-build-timestamp minute of hour e.g. '59'
+- `${build.timestamp.second}` maven-build-timestamp second of minute e.g. '30'
+- `${build.timestamp.datetime}` maven-build-timestamp formatted as `yyyyMMdd.HHmmss`e.g. '20190616.161442'
+     <br><br>
+
 - `${describe}` Will resolve to `git describe` output
 - `${describe.distance}` The distance count to last matching tag
 - `${describe.tag}` The matching tag of `git describe`

--- a/src/main/java/me/qoomon/maven/gitversioning/GitVersioningModelProcessor.java
+++ b/src/main/java/me/qoomon/maven/gitversioning/GitVersioningModelProcessor.java
@@ -27,6 +27,7 @@ import javax.inject.Singleton;
 import java.io.*;
 import java.nio.file.Files;
 import java.nio.file.StandardCopyOption;
+import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.*;
@@ -775,6 +776,18 @@ public class GitVersioningModelProcessor extends DefaultModelProcessor {
         placeholderMap.put("commit.timestamp.second", Lazy.by(() -> leftPad(String.valueOf(headCommitDateTime.get().getSecond()), 2, "0")));
         placeholderMap.put("commit.timestamp.datetime", Lazy.by(() -> headCommitDateTime.get().toEpochSecond() > 0
                 ? headCommitDateTime.get().format(DateTimeFormatter.ofPattern("yyyyMMdd.HHmmss")) : "00000000.000000"));
+
+        final Lazy<ZonedDateTime> buildCommitDateTime = Lazy.by(() -> mavenSession.getStartTime().toInstant().atZone(ZoneId.systemDefault()));
+        placeholderMap.put("build.timestamp", Lazy.by(() -> String.valueOf(buildCommitDateTime.get().toEpochSecond())));
+        placeholderMap.put("build.timestamp.year", Lazy.by(() -> String.valueOf(buildCommitDateTime.get().getYear())));
+        placeholderMap.put("build.timestamp.year.2digit", Lazy.by(() -> String.valueOf(buildCommitDateTime.get().getYear() % 100)));
+        placeholderMap.put("build.timestamp.month", Lazy.by(() -> leftPad(String.valueOf(buildCommitDateTime.get().getMonthValue()), 2, "0")));
+        placeholderMap.put("build.timestamp.day", Lazy.by(() -> leftPad(String.valueOf(buildCommitDateTime.get().getDayOfMonth()), 2, "0")));
+        placeholderMap.put("build.timestamp.hour", Lazy.by(() -> leftPad(String.valueOf(buildCommitDateTime.get().getHour()), 2, "0")));
+        placeholderMap.put("build.timestamp.minute", Lazy.by(() -> leftPad(String.valueOf(buildCommitDateTime.get().getMinute()), 2, "0")));
+        placeholderMap.put("build.timestamp.second", Lazy.by(() -> leftPad(String.valueOf(buildCommitDateTime.get().getSecond()), 2, "0")));
+        placeholderMap.put("build.timestamp.datetime", Lazy.by(() -> buildCommitDateTime.get().toEpochSecond() > 0
+                ? buildCommitDateTime.get().format(DateTimeFormatter.ofPattern("yyyyMMdd.HHmmss")) : "00000000.000000"));
 
         final String refName = gitVersionDetails.getRefName();
         final Lazy<String> refNameSlug = Lazy.by(() -> slugify(refName));


### PR DESCRIPTION
This PR introduces the placeholder `${build.timestamp}` generated from `MavenSession#getStartTime`. It has the same sub-placeholders like `${commit.timestamp}`.
The placeholder enables the possibility to build multiple artifacts with uncommited changes based on the same commit.

In my case we are building a set of rules as a zipped artifact for a ruleengine. The developers make local changes, build them uncommited and upload the artifact to a server to test the rules. Sometimes they need to upload multiple artifacts, based on the same commit but with different changes, to compare the results.

#### Example
```xml
<ref type="branch">
    <pattern><![CDATA[local/(?<feature>.+)]]></pattern>
    <version>${ref.feature}-${build.timestamp.datetime}</version>
</ref>
```

Maven build command
`mvn clean verify -Dgit.branch=local/foo`

The resulting Artifact would be something like `rules-foo-20220708.082700.zip`