### PR TITLE
allow overriding of firstParent in git describe evaluation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 # Changelog
 
+## 9.4.0
+
+##### Features
+- allow overriding of firstParent in git describe evaluation
+
 ## 9.3.4
 
 ##### Fixes

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ You can configure the version and properties adjustments for specific branches a
       - `<updatePom>` Enable(`true`) or disable(`false`) version and properties update in original pom file
         - will override global `<updatePom>` value
 
-      - `<firstParent>` Enable(`true`) or disable(`false`) following only the first parent in a merge commit
+      - `<describeTagFirstParent>` Enable(`true`) or disable(`false`) following only the first parent in a merge commit
         - default is `true`
 
 - `<rev>` Rev configuration will be used if no ref configuration is matching current git situation.

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ create or update `${rootProjectDir}/.mvn/extensions.xml` file
     <extension>
         <groupId>me.qoomon</groupId>
         <artifactId>maven-git-versioning-extension</artifactId>
-        <version>9.3.3</version>
+        <version>9.4.0</version>
     </extension>
 
 </extensions>
@@ -58,7 +58,7 @@ You can configure the version and properties adjustments for specific branches a
 ```xml
 <configuration xmlns="https://github.com/qoomon/maven-git-versioning-extension"
                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-               xsi:schemaLocation="https://github.com/qoomon/maven-git-versioning-extension https://qoomon.github.io/maven-git-versioning-extension/configuration-9.1.0.xsd">
+               xsi:schemaLocation="https://github.com/qoomon/maven-git-versioning-extension https://qoomon.github.io/maven-git-versioning-extension/configuration-9.4.0.xsd">
 
     <refs>
         <ref type="branch">
@@ -119,6 +119,9 @@ You can configure the version and properties adjustments for specific branches a
 
       - `<updatePom>` Enable(`true`) or disable(`false`) version and properties update in original pom file
         - will override global `<updatePom>` value
+
+      - `<firstParent>` Enable(`true`) or disable(`false`) following only the first parent in a merge commit
+        - default is `true`
 
 - `<rev>` Rev configuration will be used if no ref configuration is matching current git situation.
     - same as `<ref>` configuration, except `type` attribute and `<pattern>` element.

--- a/docs/configuration-9.4.0.xsd
+++ b/docs/configuration-9.4.0.xsd
@@ -41,8 +41,8 @@
     <xs:complexType name="PatchDescription">
         <xs:all>
             <xs:element name="describeTagPattern" type="xs:string" minOccurs="0"/>
+            <xs:element name="describeTagFirstParent" type="xs:boolean" minOccurs="0"/>
             <xs:element name="updatePom" type="xs:boolean" minOccurs="0"/>
-            <xs:element name="firstParent" type="xs:boolean" minOccurs="0"/>
 
             <xs:element name="version" type="xs:string" minOccurs="0"/>
             <xs:element name="properties" minOccurs="0">
@@ -59,8 +59,8 @@
         <xs:all>
             <xs:element name="pattern" type="xs:string" minOccurs="0"/>
             <xs:element name="describeTagPattern" type="xs:string" minOccurs="0"/>
+            <xs:element name="describeTagFirstParent" type="xs:boolean" minOccurs="0"/>
             <xs:element name="updatePom" type="xs:boolean" minOccurs="0"/>
-            <xs:element name="firstParent" type="xs:boolean" minOccurs="0"/>
 
             <xs:element name="version" type="xs:string" minOccurs="0"/>
             <xs:element name="properties" minOccurs="0">

--- a/docs/configuration-9.4.0.xsd
+++ b/docs/configuration-9.4.0.xsd
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+<xs:schema xmlns="https://github.com/qoomon/maven-git-versioning-extension"
+           xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           targetNamespace="https://github.com/qoomon/maven-git-versioning-extension"
+           elementFormDefault="qualified">
+
+    <xs:element name="configuration">
+        <xs:complexType>
+            <xs:all>
+                <xs:element name="disable" type="xs:boolean" minOccurs="0"/>
+
+                <xs:element name="projectVersionPattern" type="xs:string" minOccurs="0"/>
+
+                <xs:element name="describeTagPattern" type="xs:string" minOccurs="0"/>
+                <xs:element name="updatePom" type="xs:boolean" minOccurs="0"/>
+
+                <xs:element name="refs" minOccurs="0">
+                    <xs:complexType>
+                        <xs:sequence>
+                            <xs:element name="ref" type="RefPatchDescription" minOccurs="0" maxOccurs="unbounded"/>
+                        </xs:sequence>
+
+                        <xs:attribute name="considerTagsOnBranches" type="xs:boolean"/>
+                    </xs:complexType>
+                </xs:element>
+
+                <xs:element name="rev" type="PatchDescription" minOccurs="0"/>
+
+                <xs:element name="relatedProjects" minOccurs="0">
+                    <xs:complexType>
+                        <xs:sequence>
+                            <xs:element name="project" type="RelatedProject" minOccurs="0" maxOccurs="unbounded"/>
+                        </xs:sequence>
+                    </xs:complexType>
+                </xs:element>
+            </xs:all>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:complexType name="PatchDescription">
+        <xs:all>
+            <xs:element name="describeTagPattern" type="xs:string" minOccurs="0"/>
+            <xs:element name="updatePom" type="xs:boolean" minOccurs="0"/>
+            <xs:element name="firstParent" type="xs:boolean" minOccurs="0"/>
+
+            <xs:element name="version" type="xs:string" minOccurs="0"/>
+            <xs:element name="properties" minOccurs="0">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:any minOccurs="0" maxOccurs="unbounded" processContents="skip"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+        </xs:all>
+    </xs:complexType>
+
+    <xs:complexType name="RefPatchDescription">
+        <xs:all>
+            <xs:element name="pattern" type="xs:string" minOccurs="0"/>
+            <xs:element name="describeTagPattern" type="xs:string" minOccurs="0"/>
+            <xs:element name="updatePom" type="xs:boolean" minOccurs="0"/>
+            <xs:element name="firstParent" type="xs:boolean" minOccurs="0"/>
+
+            <xs:element name="version" type="xs:string" minOccurs="0"/>
+            <xs:element name="properties" minOccurs="0">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:any minOccurs="0" maxOccurs="unbounded" processContents="skip"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+        </xs:all>
+
+        <xs:attribute name="type" use="required">
+            <xs:simpleType>
+                <xs:restriction base="xs:string">
+                    <xs:enumeration value="tag"/>
+                    <xs:enumeration value="branch"/>
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="RelatedProject">
+        <xs:all>
+            <xs:element name="groupId" type="xs:string"/>
+            <xs:element name="artifactId" type="xs:string"/>
+        </xs:all>
+    </xs:complexType>
+
+</xs:schema>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>me.qoomon</groupId>
     <artifactId>maven-git-versioning-extension</artifactId>
-    <version>9.3.4</version>
+    <version>9.4.0</version>
     <packaging>maven-plugin</packaging>
 
     <name>Maven Git Versioning Extension</name>
@@ -116,6 +116,12 @@
             <scope>test</scope>
         </dependency>
 
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <version>1.7.36</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/me/qoomon/gitversioning/commons/GitSituation.java
+++ b/src/main/java/me/qoomon/gitversioning/commons/GitSituation.java
@@ -13,7 +13,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Supplier;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 
 import static java.time.Instant.EPOCH;
 import static java.time.ZoneOffset.UTC;
@@ -38,6 +37,9 @@ public class GitSituation {
     private final Supplier<Boolean> clean = Lazy.by(this::clean);
 
     private Pattern describeTagPattern = Pattern.compile(".*");
+
+    private boolean firstParent = true;
+
     private Supplier<GitDescription> description = Lazy.by(this::describe);
 
     public GitSituation(Repository repository) throws IOException {
@@ -153,6 +155,14 @@ public class GitSituation {
         return describeTagPattern;
     }
 
+    public boolean isFirstParent() {
+        return firstParent;
+    }
+
+    public void setFirstParent(boolean firstParent) {
+        this.firstParent = firstParent;
+    }
+
     public GitDescription getDescription() {
         return description.get();
     }
@@ -178,6 +188,6 @@ public class GitSituation {
     }
 
     private GitDescription describe() throws IOException {
-        return GitUtil.describe(head, describeTagPattern, repository);
+        return GitUtil.describe(head, describeTagPattern, repository, firstParent);
     }
 }

--- a/src/main/java/me/qoomon/gitversioning/commons/GitUtil.java
+++ b/src/main/java/me/qoomon/gitversioning/commons/GitUtil.java
@@ -47,7 +47,7 @@ public final class GitUtil {
         return reverseTagRefMap(repository).getOrDefault(revObjectId, emptyList());
     }
 
-    public static GitDescription describe(ObjectId revObjectId, Pattern tagPattern, Repository repository) throws IOException {
+    public static GitDescription describe(ObjectId revObjectId, Pattern tagPattern, Repository repository, boolean firstParent) throws IOException {
         if (revObjectId == null) {
             return new GitDescription(NO_COMMIT, "root", 0);
         }
@@ -57,7 +57,7 @@ public final class GitUtil {
         // Walk back commit ancestors looking for tagged one
         try (RevWalk walk = new RevWalk(repository)) {
             walk.setRetainBody(false);
-            walk.setFirstParent(true);
+            walk.setFirstParent(firstParent);
             walk.markStart(walk.parseCommit(revObjectId));
             Iterator<RevCommit> walkIterator = walk.iterator();
             int depth = 0;

--- a/src/main/java/me/qoomon/maven/gitversioning/Configuration.java
+++ b/src/main/java/me/qoomon/maven/gitversioning/Configuration.java
@@ -86,6 +86,8 @@ public class Configuration {
         public Map<String, String> properties = new HashMap<>();
 
         public Boolean updatePom;
+
+        public Boolean firstParent;
     }
 
     @JsonInclude(NON_NULL)
@@ -112,6 +114,7 @@ public class Configuration {
             this.pattern = pattern != null ? pattern.pattern() : null;
             this.describeTagPattern = description.describeTagPattern;
             this.updatePom = description.updatePom;
+            this.firstParent = description.firstParent;
             this.version = description.version;
             this.properties = new HashMap<>(description.properties);
         }

--- a/src/main/java/me/qoomon/maven/gitversioning/Configuration.java
+++ b/src/main/java/me/qoomon/maven/gitversioning/Configuration.java
@@ -87,7 +87,7 @@ public class Configuration {
 
         public Boolean updatePom;
 
-        public Boolean firstParent;
+        public Boolean describeTagFirstParent;
     }
 
     @JsonInclude(NON_NULL)
@@ -114,7 +114,7 @@ public class Configuration {
             this.pattern = pattern != null ? pattern.pattern() : null;
             this.describeTagPattern = description.describeTagPattern;
             this.updatePom = description.updatePom;
-            this.firstParent = description.firstParent;
+            this.describeTagFirstParent = description.describeTagFirstParent;
             this.version = description.version;
             this.properties = new HashMap<>(description.properties);
         }

--- a/src/main/java/me/qoomon/maven/gitversioning/GitVersioningModelProcessor.java
+++ b/src/main/java/me/qoomon/maven/gitversioning/GitVersioningModelProcessor.java
@@ -199,9 +199,9 @@ public class GitVersioningModelProcessor extends DefaultModelProcessor {
             logger.info("  describeTagPattern: " + patchDescription.describeTagPattern);
             gitSituation.setDescribeTagPattern(patchDescription.describeTagPattern());
         }
-        if (patchDescription.firstParent != null) {
-            logger.info("  firstParent: " + patchDescription.firstParent);
-            gitSituation.setFirstParent(patchDescription.firstParent);
+        if (patchDescription.describeTagFirstParent != null) {
+            logger.info("  describeTagFirstParent: " + patchDescription.describeTagFirstParent);
+            gitSituation.setFirstParent(patchDescription.describeTagFirstParent);
         }
         if (patchDescription.version != null) {
             logger.info("  version: " + patchDescription.version);

--- a/src/main/java/me/qoomon/maven/gitversioning/GitVersioningModelProcessor.java
+++ b/src/main/java/me/qoomon/maven/gitversioning/GitVersioningModelProcessor.java
@@ -199,6 +199,10 @@ public class GitVersioningModelProcessor extends DefaultModelProcessor {
             logger.info("  describeTagPattern: " + patchDescription.describeTagPattern);
             gitSituation.setDescribeTagPattern(patchDescription.describeTagPattern());
         }
+        if (patchDescription.firstParent != null) {
+            logger.info("  firstParent: " + patchDescription.firstParent);
+            gitSituation.setFirstParent(patchDescription.firstParent);
+        }
         if (patchDescription.version != null) {
             logger.info("  version: " + patchDescription.version);
         }

--- a/src/test/java/me/qoomon/gitversioning/commons/GitUtilTest.java
+++ b/src/test/java/me/qoomon/gitversioning/commons/GitUtilTest.java
@@ -187,7 +187,7 @@ class GitUtilTest {
         git.tag().setName(givenTagName).setAnnotated(true).setObjectId(givenCommit).setMessage(".").call();
 
         // when
-        GitDescription description = GitUtil.describe(head(git), Pattern.compile("v.+"), git.getRepository());
+        GitDescription description = GitUtil.describe(head(git), Pattern.compile("v.+"), git.getRepository(), true);
 
         // then
         assertThat(description).satisfies(it -> {

--- a/src/test/java/me/qoomon/maven/gitversioning/GitVersioningExtensionIT.java
+++ b/src/test/java/me/qoomon/maven/gitversioning/GitVersioningExtensionIT.java
@@ -840,7 +840,7 @@ class GitVersioningExtensionIT {
             writeExtensionsFile(projectDir);
             writeExtensionConfigFile(projectDir, new Configuration() {{
                 RefPatchDescription versionDescription = createVersionDescription(BRANCH, "${describe.tag.version}");
-                versionDescription.firstParent = firstParent;
+                versionDescription.describeTagFirstParent = firstParent;
                 refs.list.add(versionDescription);
             }});
 

--- a/src/test/java/me/qoomon/maven/gitversioning/GitVersioningExtensionIT.java
+++ b/src/test/java/me/qoomon/maven/gitversioning/GitVersioningExtensionIT.java
@@ -12,6 +12,7 @@ import org.apache.maven.model.DependencyManagement;
 import org.apache.maven.model.Model;
 import org.apache.maven.model.Parent;
 import org.eclipse.jgit.api.Git;
+import org.eclipse.jgit.api.MergeCommand;
 import org.eclipse.jgit.lib.Ref;
 import org.eclipse.jgit.revwalk.RevCommit;
 import org.junit.jupiter.api.Test;
@@ -807,9 +808,55 @@ class GitVersioningExtensionIT {
             assertThat(gitVersionedPomModel.getVersion()).isEqualTo(expectedVersion);
         }
 
-     }
+    }
 
+    @Test
+    void apply_TagOnMergedBranchWithFirstParent() throws Exception {
+        apply_TagOnMerged(true);
+    }
 
+    @Test
+    void apply_TagOnMergedBranchWithoutFirstParent() throws Exception {
+        apply_TagOnMerged(false);
+    }
+
+    private void apply_TagOnMerged(final boolean firstParent) throws Exception {
+        String tagOnMaster = "2.0.4-tag-on-master";
+        String tagOnBranch = "2.0.4-tag-on-branch";
+        try (Git git = Git.init().setInitialBranch(MASTER).setDirectory(projectDir.toFile()).call()) {
+            RevCommit initialCommit = git.commit().setMessage("initial commit").setAllowEmpty(true).call();
+            git.tag().setName("2.0.4-tag-on-initial").call();
+            git.commit().setMessage("commit on master").setAllowEmpty(true).call();
+            git.tag().setName(tagOnMaster).call();
+            git.checkout().setStartPoint(initialCommit).setCreateBranch(true).setName("branch").call();
+            // make sure the commit on the branch is newer
+            Thread.sleep(2000);
+            RevCommit branchCommit = git.commit().setMessage("commit on branch").setAllowEmpty(true).call();
+            git.tag().setName(tagOnBranch).call();
+            git.checkout().setName(MASTER).call();
+            git.merge().include(branchCommit).setFastForward(MergeCommand.FastForwardMode.NO_FF).setCommit(true).call();
+
+            writeModel(projectDir.resolve("pom.xml").toFile(), pomModel);
+            writeExtensionsFile(projectDir);
+            writeExtensionConfigFile(projectDir, new Configuration() {{
+                RefPatchDescription versionDescription = createVersionDescription(BRANCH, "${describe.tag.version}");
+                versionDescription.firstParent = firstParent;
+                refs.list.add(versionDescription);
+            }});
+
+            // When
+            Verifier verifier = getVerifier(projectDir);
+            verifier.executeGoal("verify");
+
+            // Then
+            verifier.verifyErrorFreeLog();
+            String expectedVersion = firstParent ? tagOnMaster : tagOnBranch;
+            verifier.verifyTextInLog("Building " + pomModel.getArtifactId() + " " + expectedVersion);
+
+            Model gitVersionedPomModel = readModel(projectDir.resolve(GIT_VERSIONING_POM_NAME).toFile());
+            assertThat(gitVersionedPomModel.getVersion()).isEqualTo(expectedVersion);
+        }
+    }
     // TODO add tests for property updates
 
 


### PR DESCRIPTION
Support setting the `firstParent` option for `git describe`