### PR TITLE
Support overwriting properties defined in parent #235

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,16 @@ You can configure the version and properties adjustments for specific branches a
           - `value` The new value format of the property, see [Format Placeholders](#format-placeholders)
             <br><br>
 
+      - `<userProperties>`
+        - `<name>value</name>` A property definition to add a user property to the maven session, active during the build. UserProperties with the same name of a property in the pom or this configuration file will take precedence as that is how maven handles user properties.
+          - `<name>` The property name
+          - `value` The new value format of the property, see [Format Placeholders](#format-placeholders)
+        ```xml
+        <userProperties>
+            <test.property>${ref}</test.property>
+        </userProperties>
+        ```
+      
       - `<updatePom>` Enable(`true`) or disable(`false`) version and properties update in original pom file
         - will override global `<updatePom>` value
 

--- a/src/main/java/me/qoomon/maven/gitversioning/Configuration.java
+++ b/src/main/java/me/qoomon/maven/gitversioning/Configuration.java
@@ -87,6 +87,11 @@ public class Configuration {
         // TODO  @JsonDeserialize(using = IgnoreWhitespaceDeserializer.class)
         public Map<String, String> properties = new HashMap<>();
 
+        @JsonInclude(NON_EMPTY)
+        @JacksonXmlElementWrapper(useWrapping = false)
+        // TODO  @JsonDeserialize(using = IgnoreWhitespaceDeserializer.class)
+        public Map<String, String> userProperties = new HashMap<>();
+
         public Boolean updatePom;
 
         public Boolean describeTagFirstParent;

--- a/src/main/java/me/qoomon/maven/gitversioning/GitVersioningModelProcessor.java
+++ b/src/main/java/me/qoomon/maven/gitversioning/GitVersioningModelProcessor.java
@@ -224,9 +224,10 @@ public class GitVersioningModelProcessor extends DefaultModelProcessor {
         }
         if (!patchDescription.userProperties.isEmpty()) {
             logger.info("  userProperties: ");
+            String projectVersion = GAV.of(projectModel).getVersion();
             patchDescription.userProperties.forEach((key, value) -> {
                 logger.info("    " + key + " - " + value);
-                mavenSession.getUserProperties().put(key, getGitPropertyValue(value, "", GAV.of(projectModel).getVersion()))
+                mavenSession.getUserProperties().put(key, getGitPropertyValue(value, "", projectVersion))
             });
         }
         updatePom = getUpdatePomOption(patchDescription);

--- a/src/main/java/me/qoomon/maven/gitversioning/GitVersioningModelProcessor.java
+++ b/src/main/java/me/qoomon/maven/gitversioning/GitVersioningModelProcessor.java
@@ -222,7 +222,10 @@ public class GitVersioningModelProcessor extends DefaultModelProcessor {
         }
         if (!patchDescription.userProperties.isEmpty()) {
             logger.info("  userProperties: ");
-            patchDescription.userProperties.forEach((key, value) -> logger.info("    " + key + " - " + value));
+            patchDescription.userProperties.forEach((key, value) -> {
+                logger.info("    " + key + " - " + value);
+                mavenSession.getUserProperties().put(k, getGitPropertyValue(value, "", GAV.of(projectModel).getVersion()))
+            });
         }
         updatePom = getUpdatePomOption(patchDescription);
         if (updatePom) {
@@ -237,8 +240,6 @@ public class GitVersioningModelProcessor extends DefaultModelProcessor {
             logger.debug(buffer().strong("related projects:").toString());
             relatedProjects.forEach(gav -> logger.debug("  " + gav));
         }
-
-        patchDescription.userProperties.forEach((k, v) -> mavenSession.getUserProperties().put(k,getGitPropertyValue(v, "", GAV.of(projectModel).getVersion())));
 
         logger.info("");
     }

--- a/src/main/java/me/qoomon/maven/gitversioning/GitVersioningModelProcessor.java
+++ b/src/main/java/me/qoomon/maven/gitversioning/GitVersioningModelProcessor.java
@@ -222,20 +222,21 @@ public class GitVersioningModelProcessor extends DefaultModelProcessor {
                 logger.info("    " + key + " - " + value);
             });
         }
+
+        globalFormatPlaceholderMap = generateGlobalFormatPlaceholderMap(gitSituation, gitVersionDetails, mavenSession);
+
         if (!patchDescription.userProperties.isEmpty()) {
             logger.info("  userProperties: ");
             String projectVersion = GAV.of(projectModel).getVersion();
             patchDescription.userProperties.forEach((key, value) -> {
                 logger.info("    " + key + " - " + value);
-                mavenSession.getUserProperties().put(key, getGitPropertyValue(value, "", projectVersion))
+                mavenSession.getUserProperties().put(key, getGitPropertyValue(value, "", projectVersion));
             });
         }
         updatePom = getUpdatePomOption(patchDescription);
         if (updatePom) {
             logger.info("  updatePom: " + updatePom);
         }
-
-        globalFormatPlaceholderMap = generateGlobalFormatPlaceholderMap(gitSituation, gitVersionDetails, mavenSession);
 
         // determine related projects
         relatedProjects = determineRelatedProjects(projectModel);

--- a/src/main/java/me/qoomon/maven/gitversioning/GitVersioningModelProcessor.java
+++ b/src/main/java/me/qoomon/maven/gitversioning/GitVersioningModelProcessor.java
@@ -220,6 +220,10 @@ public class GitVersioningModelProcessor extends DefaultModelProcessor {
             logger.info("  properties: " + patchDescription.version);
             patchDescription.properties.forEach((key, value) -> logger.info("    " + key + " - " + value));
         }
+        if (!patchDescription.userProperties.isEmpty()) {
+            logger.info("  userProperties: ");
+            patchDescription.userProperties.forEach((key, value) -> logger.info("    " + key + " - " + value));
+        }
         updatePom = getUpdatePomOption(patchDescription);
         if (updatePom) {
             logger.info("  updatePom: " + updatePom);
@@ -233,6 +237,8 @@ public class GitVersioningModelProcessor extends DefaultModelProcessor {
             logger.debug(buffer().strong("related projects:").toString());
             relatedProjects.forEach(gav -> logger.debug("  " + gav));
         }
+
+        patchDescription.userProperties.forEach((k, v) -> mavenSession.getUserProperties().put(k,getGitPropertyValue(v, "", GAV.of(projectModel).getVersion())));
 
         logger.info("");
     }

--- a/src/main/java/me/qoomon/maven/gitversioning/GitVersioningModelProcessor.java
+++ b/src/main/java/me/qoomon/maven/gitversioning/GitVersioningModelProcessor.java
@@ -217,14 +217,16 @@ public class GitVersioningModelProcessor extends DefaultModelProcessor {
             logger.info("  version: " + patchDescription.version);
         }
         if (!patchDescription.properties.isEmpty()) {
-            logger.info("  properties: " + patchDescription.version);
-            patchDescription.properties.forEach((key, value) -> logger.info("    " + key + " - " + value));
+            logger.info("  properties: ");
+            patchDescription.properties.forEach((key, value) -> {
+                logger.info("    " + key + " - " + value);
+            });
         }
         if (!patchDescription.userProperties.isEmpty()) {
             logger.info("  userProperties: ");
             patchDescription.userProperties.forEach((key, value) -> {
                 logger.info("    " + key + " - " + value);
-                mavenSession.getUserProperties().put(k, getGitPropertyValue(value, "", GAV.of(projectModel).getVersion()))
+                mavenSession.getUserProperties().put(key, getGitPropertyValue(value, "", GAV.of(projectModel).getVersion()))
             });
         }
         updatePom = getUpdatePomOption(patchDescription);


### PR DESCRIPTION
Added a new configuration section for userProperties which are added to the mavenSession.userProperties at startup.

Proposes an alternative to add properties that are not yet defined in the pom (under root or profiles).
A user can decide to define userProperties so he knows exactly what is going to happen with them.
They will be added to the mavenSession from the start and available during the build for processing AND in case a user property is defined that exists somewhere in the pom, the userProperty will take precedence over the existing property as that is how maven handles user-defined properties.

Example

  ```
<ref type="branch">
      ...
      <properties>
          <test.property.1>...</test.property.1>
          <test.property.2>...</test.property.2>
      </properties>
      <userProperties>
          <test.property.new>...</test.property.new>
      </userProperties>
  </ref>
```
