### PR TITLE
Delegate Model Processing to parent implementation

### DIFF
--- a/src/main/java/me/qoomon/maven/gitversioning/GitVersioningModelProcessor.java
+++ b/src/main/java/me/qoomon/maven/gitversioning/GitVersioningModelProcessor.java
@@ -233,9 +233,7 @@ public class GitVersioningModelProcessor implements ModelProcessor {
         }
         if (!patchDescription.properties.isEmpty()) {
             logger.info("  properties: ");
-            patchDescription.properties.forEach((key, value) -> {
-                logger.info("    {} - {}", key, value);
-            });
+            patchDescription.properties.forEach((key, value) -> logger.info("    {} - {}", key, value));
         }
 
         globalFormatPlaceholderMap = generateGlobalFormatPlaceholderMap(gitSituation, gitVersionDetails, mavenSession);
@@ -308,8 +306,10 @@ public class GitVersioningModelProcessor implements ModelProcessor {
         // add current project model to session project models
         sessionModelCache.put(canonicalProjectPomFile, projectModel);
 
-        // log project header
-        logger.info(projectLogHeader(projectGAV));
+        if (logger.isInfoEnabled()) {
+            // log project header
+            logger.info(projectLogHeader(projectGAV));
+        }
 
         updateModel(projectModel, gitVersionDetails.getPatchDescription());
 
@@ -381,7 +381,7 @@ public class GitVersioningModelProcessor implements ModelProcessor {
             GAV parentGAV = GAV.of(parent);
             if (isRelatedProject(parentGAV)) {
                 String gitVersion = getGitVersion(versionFormat, parentGAV.getVersion());
-                logger.debug("set parent version to " + gitVersion + " (" + parentGAV + ")");
+                logger.debug("set parent version to {} ({})", gitVersion, parentGAV);
                 parent.setVersion(gitVersion);
             }
         }
@@ -406,7 +406,7 @@ public class GitVersioningModelProcessor implements ModelProcessor {
             if (propertyFormat != null) {
                 String gitPropertyValue = getGitPropertyValue(propertyFormat, (String) modelPropertyValue, originalProjectGAV.getVersion());
                 if (!gitPropertyValue.equals(modelPropertyValue)) {
-                    logger.info("set property " + modelPropertyName + " to " + gitPropertyValue);
+                    logger.info("set property {} to {}", modelPropertyName, gitPropertyValue);
                     model.addProperty((String) modelPropertyName, gitPropertyValue);
                 }
             }
@@ -700,9 +700,9 @@ public class GitVersioningModelProcessor implements ModelProcessor {
                     String commitBranch = System.getenv("CI_COMMIT_BRANCH");
                     String commitTag = System.getenv("CI_COMMIT_TAG");
                     String mrSourceBranch = System.getenv("CI_MERGE_REQUEST_SOURCE_BRANCH_NAME");
-                    logger.debug("  CI_COMMIT_BRANCH: " + commitBranch);
-                    logger.debug("  CI_COMMIT_TAG: " + commitTag);
-                    logger.debug("  CI_MERGE_REQUEST_SOURCE_BRANCH_NAME: " + mrSourceBranch);
+                    logger.debug("  CI_COMMIT_BRANCH: {}", commitBranch);
+                    logger.debug("  CI_COMMIT_TAG: {}", commitTag);
+                    logger.debug("  CI_MERGE_REQUEST_SOURCE_BRANCH_NAME: {}", mrSourceBranch);
 
                     if (commitBranch != null) {
                         setBranch(commitBranch);
@@ -723,8 +723,8 @@ public class GitVersioningModelProcessor implements ModelProcessor {
                     logger.info("gather git situation from Circle CI environment variables: CIRCLE_BRANCH and CIRCLE_TAG");
                     String commitBranch = System.getenv("CIRCLE_BRANCH");
                     String commitTag = System.getenv("CIRCLE_TAG");
-                    logger.debug("  CIRCLE_BRANCH: " + commitBranch);
-                    logger.debug("  CIRCLE_TAG: " + commitTag);
+                    logger.debug("  CIRCLE_BRANCH: {}", commitBranch);
+                    logger.debug("  CIRCLE_TAG: {}", commitTag);
 
                     if (commitBranch != null) {
                         setBranch(commitBranch);
@@ -742,8 +742,8 @@ public class GitVersioningModelProcessor implements ModelProcessor {
                     logger.info("gather git situation from jenkins environment variables: BRANCH_NAME and TAG_NAME");
                     String commitBranch = System.getenv("BRANCH_NAME");
                     String commitTag = System.getenv("TAG_NAME");
-                    logger.debug("  BRANCH_NAME: " + commitBranch);
-                    logger.debug("  TAG_NAME: " + commitTag);
+                    logger.debug("  BRANCH_NAME: {}", commitBranch);
+                    logger.debug("  TAG_NAME: {}", commitTag);
 
                     if (commitBranch != null) {
                         if (commitBranch.equals(commitTag)) {
@@ -760,17 +760,17 @@ public class GitVersioningModelProcessor implements ModelProcessor {
 
 
             protected void setBranch(String branch) {
-                logger.debug("override git branch with " + branch);
+                logger.debug("override git branch with {}", branch);
                 super.setBranch(branch);
             }
 
             protected void setTags(List<String> tags) {
-                logger.debug("override git tags with single tag " + tags);
+                logger.debug("override git tags with single tag {}", tags);
                 super.setTags(tags);
             }
 
             protected void addTag(String tag) {
-                logger.debug("add git tag " + tag);
+                logger.debug("add git tag {}", tag);
                 super.addTag(tag);
             }
         };

--- a/src/main/java/me/qoomon/maven/gitversioning/GitVersioningModelProcessor.java
+++ b/src/main/java/me/qoomon/maven/gitversioning/GitVersioningModelProcessor.java
@@ -143,6 +143,8 @@ public class GitVersioningModelProcessor implements ModelProcessor {
             logger.info(extensionLogHeader(BuildProperties.projectGAV()));
         }
 
+        // In case another ModelProcessor is used (like for example polyglot extension),
+        // we need to work on the POM possibly translated into XML
         File pomFile = locatePom(projectModel.getProjectDirectory());
         if (pomFile == null) {
             logger.debug("skip - project model does not belong to a local project");
@@ -321,6 +323,8 @@ public class GitVersioningModelProcessor implements ModelProcessor {
             logger.debug("updating original POM file");
             Files.copy(
                     gitVersionedPomFile.toPath(),
+                    // In case another ModelProcessor is used (like for example polyglot extension),
+                    // we need to work on the POM possibly translated into XML
                     locatePom(projectModel.getProjectDirectory()).toPath(),
                     StandardCopyOption.REPLACE_EXISTING);
         }
@@ -1196,7 +1200,8 @@ public class GitVersioningModelProcessor implements ModelProcessor {
         File gitVersionedPomFile = new File(projectModel.getProjectDirectory(), GIT_VERSIONING_POM_NAME);
         logger.debug("generate {}", gitVersionedPomFile);
 
-        // read original pom file
+        // In case another ModelProcessor is used (like for example polyglot extension),
+        // we need to work on the POM possibly translated into XML
         Document gitVersionedPomDocument = readXml(this.locatePom(projectModel.getProjectDirectory()));
         Element projectElement = gitVersionedPomDocument.getChild("project");
 

--- a/src/main/java/me/qoomon/maven/gitversioning/GitVersioningModelProcessor.java
+++ b/src/main/java/me/qoomon/maven/gitversioning/GitVersioningModelProcessor.java
@@ -116,7 +116,10 @@ public class GitVersioningModelProcessor implements ModelProcessor {
 
     private final Map<File, Model> sessionModelCache = new HashMap<>();
 
-   
+    @Override
+    public File locatePom(File projectDirectory) {
+        return delegatedModelProcessor.locatePom(projectDirectory);
+    }
 
     @Override
     public Model read(File input, Map<String, ?> options) throws IOException {
@@ -1440,10 +1443,5 @@ public class GitVersioningModelProcessor implements ModelProcessor {
     private static String increase(String number, long increment) {
         String sanitized = number.isEmpty() ? "0" : number;
         return String.format("%0" + sanitized.length() + "d", Long.parseLong(number.isEmpty() ? "0" : number) + increment);
-    }
-
-    @Override
-    public File locatePom(File projectDirectory) {
-        return delegatedModelProcessor.locatePom(projectDirectory);
     }
 }

--- a/src/main/java/me/qoomon/maven/gitversioning/GitVersioningModelProcessor.java
+++ b/src/main/java/me/qoomon/maven/gitversioning/GitVersioningModelProcessor.java
@@ -318,7 +318,7 @@ public class GitVersioningModelProcessor implements ModelProcessor {
             logger.debug("updating original POM file");
             Files.copy(
                     gitVersionedPomFile.toPath(),
-                    projectModel.getPomFile().toPath(),
+                    locatePom(projectModel.getProjectDirectory()).toPath(),
                     StandardCopyOption.REPLACE_EXISTING);
         }
 


### PR DESCRIPTION
By default, _Eclipse Sisu_ IoC implementation knows all candidates of `org.apache.maven.model.building.ModelProcessor` implementation.
So, there is always `org.apache.maven.model.building.DefaultModelProcessor` in this list (as well as the current `me.qoomon.maven.gitversioning.GitVersioningModelProcessor`).

When a project uses another custom `ModelProcessor` like the [polyglot](https://github.com/takari/polyglot-maven) extension (see [Maven Website](https://maven.apache.org/extensions/index.html)), this list also contains this alternative implementation.

This change allows delegating core methods (`File locatePom( File projectDirectory )` and `Model read(...)`) to the "parent implementation" (defaults to `org.apache.maven.model.building. ModelProcessor` or a custom implementation if applicable).

This PR fixes #268 