### PR TITLE
Add an option to not have full depth when no tag matches the expression

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,7 +236,9 @@ e.g `${dirty:-SNAPSHOT}` resolves to `-SNAPSHOT` instead of `-DIRTY`
 
 - `${describe}` Will resolve to `git describe` output
 - `${describe.distance}` The distance count to last matching tag
+- `${describe.distanceOrZero}` The distance count to last matching tag or 0 if no tag is found
 - `${describe.distance.snapshot}` Empty string on matching tag, `-SNAPSHOT` if `describe.distance > 0` 
+- `${describe.distanceOrZero.snapshot}` Empty string on matching tag, `-SNAPSHOT` if `describe.distanceOrZero > 0` 
 - `${describe.tag}` The matching tag of `git describe`
   - `${describe.tag.version}` the tag version determined by regex `(?<version>(?<core>(?<major>\d+)(?:\.(?<minor>\d+)(?:\.(?<patch>\d+))?)?)(?:-(?<label>.*))?)`
     - `${describe.tag.version.core}` the core version component of `${describe.tag.version}` e.g. '1.2.3' 
@@ -247,11 +249,15 @@ e.g `${dirty:-SNAPSHOT}` resolves to `-SNAPSHOT` instead of `-DIRTY`
     - `${describe.tag.version.patch}` the patch version component of `${describe.tag.version}` e.g. '3'
       - `${describe.tag.version.patch.next}` the `${describe.tag.version.patch}` increased by 1 e.g. '4'
       - `${describe.tag.version.patch.plus.describe.distance}` the `${describe.tag.version.patch}` increased by `${describe.distance}` e.g. '2'
+      - `${describe.tag.version.patch.plus.describe.distanceOrZero}` the `${describe.tag.version.patch}` increased by `${describe.distanceOrZero}` e.g. '2'
       - `${describe.tag.version.patch.next.plus.describe.distance}` the `${describe.tag.version.patch.next}` increased by `${describe.distance}` e.g. '3'
+      - `${describe.tag.version.patch.next.plus.describe.distanceOrZero}` the `${describe.tag.version.patch.next}` increased by `${describe.distanceOrZero}` e.g. '3'
     - `${describe.tag.version.label}` the label version component of `${describe.tag.version}` e.g. 'SNAPSHOT'
       - `${describe.tag.version.label.next}` the `${describe.tag.version.label}` converted to an integer and increased by 1 e.g. '6'
       - `${describe.tag.version.label.plus.describe.distance}` the `${describe.tag.version.label}` increased by `${describe.distance}` e.g. '2'
+      - `${describe.tag.version.label.plus.describe.distanceOrZero}` the `${describe.tag.version.label}` increased by `${describe.distanceOrZero}` e.g. '2'
       - `${describe.tag.version.label.next.plus.describe.distance}` the `${describe.tag.version.label.next}` increased by `${describe.distance}` e.g. '3'
+      - `${describe.tag.version.label.next.plus.describe.distanceOrZero}` the `${describe.tag.version.label.next}` increased by `${describe.distanceOrZero}` e.g. '3'
 - Describe Tag Pattern Groups
     - Content of regex groups in `<describeTagPattern>` can be addressed like this:
     - `${describe.tag.GROUP_NAME}` `${describe.tag.GROUP_NAME.slug}`

--- a/src/main/java/me/qoomon/gitversioning/commons/GitDescription.java
+++ b/src/main/java/me/qoomon/gitversioning/commons/GitDescription.java
@@ -4,11 +4,13 @@ public class GitDescription {
     private final String commit;
     private final String tag;
     private final int distance;
+    private final boolean foundTag;
 
-    public GitDescription(String commit, String tag, int distance) {
+    public GitDescription(String commit, String tag, int distance, boolean foundTag) {
         this.commit = commit;
         this.tag = tag;
         this.distance = distance;
+        this.foundTag = foundTag;
     }
 
     public String getCommit() {
@@ -21,6 +23,10 @@ public class GitDescription {
 
     public int getDistance() {
         return distance;
+    }
+
+    public int getDistanceOrZero() {
+        return foundTag ? distance : 0;
     }
 
     @Override

--- a/src/main/java/me/qoomon/gitversioning/commons/GitUtil.java
+++ b/src/main/java/me/qoomon/gitversioning/commons/GitUtil.java
@@ -53,7 +53,7 @@ public final class GitUtil {
     public static GitDescription describe(ObjectId revObjectId, Pattern tagPattern, Repository repository, boolean firstParent) throws IOException {
         Repository commonRepository = worktreesFix_getCommonRepository(repository);
         if (revObjectId == null) {
-            return new GitDescription(NO_COMMIT, "root", 0);
+            return new GitDescription(NO_COMMIT, "root", 0, false);
         }
 
         Map<ObjectId, List<String>> objectIdListMap = reverseTagRefMap(repository);
@@ -72,7 +72,7 @@ public final class GitUtil {
                         .findFirst();
 
                 if (matchingTag.isPresent()) {
-                    return new GitDescription(revObjectId.getName(), matchingTag.get(), depth);
+                    return new GitDescription(revObjectId.getName(), matchingTag.get(), depth, true);
                 }
                 depth++;
             }
@@ -81,7 +81,7 @@ public final class GitUtil {
                 throw new IllegalStateException("couldn't find matching tag in shallow git repository");
             }
 
-            return new GitDescription(revObjectId.getName(), "root", depth);
+            return new GitDescription(revObjectId.getName(), "root", depth, false);
         }
     }
 

--- a/src/main/java/me/qoomon/maven/gitversioning/GitVersioningModelProcessor.java
+++ b/src/main/java/me/qoomon/maven/gitversioning/GitVersioningModelProcessor.java
@@ -966,14 +966,9 @@ public class GitVersioningModelProcessor implements ModelProcessor {
         placeholderMap.put("describe.tag.version.label.next", Lazy.by(() -> increase(placeholderMap.get("describe.tag.version.label").get(), 1)));
 
         final Lazy<Integer> descriptionDistance = Lazy.by(() -> description.get().getDistance());
-        placeholderMap.put("describe.distance", Lazy.by(() -> String.valueOf(descriptionDistance.get())));
-        placeholderMap.put("describe.distance.snapshot", Lazy.by(() -> (descriptionDistance.get() == 0 ? "" : "-SNAPSHOT")));
-
-        placeholderMap.put("describe.tag.version.patch.plus.describe.distance", Lazy.by(() -> increase(placeholderMap.get("describe.tag.version.patch").get(), descriptionDistance.get())));
-        placeholderMap.put("describe.tag.version.patch.next.plus.describe.distance", Lazy.by(() -> increase(placeholderMap.get("describe.tag.version.patch.next").get(), descriptionDistance.get())));
-
-        placeholderMap.put("describe.tag.version.label.plus.describe.distance", Lazy.by(() -> increase(placeholderMap.get("describe.tag.version.label").get(), descriptionDistance.get())));
-        placeholderMap.put("describe.tag.version.label.next.plus.describe.distance", Lazy.by(() -> increase(placeholderMap.get("describe.tag.version.label.next").get(), descriptionDistance.get())));
+        setDescribeDistancePlaceholders(placeholderMap, descriptionDistance, "distance");
+        final Lazy<Integer> descriptionDistanceOrZero = Lazy.by(() -> description.get().getDistanceOrZero());
+        setDescribeDistancePlaceholders(placeholderMap, descriptionDistanceOrZero, "distanceOrZero");
 
         // describe tag pattern groups
         final Lazy<Map<String, String>> describeTagPatternValues = Lazy.by(
@@ -1000,6 +995,17 @@ public class GitVersioningModelProcessor implements ModelProcessor {
         System.getenv().forEach((key, value) -> placeholderMap.put("env." + key, () -> value));
 
         return placeholderMap;
+    }
+
+    private static void setDescribeDistancePlaceholders(Map<String, Supplier<String>> placeholderMap, Lazy<Integer> descriptionDistance, String distanceName) {
+        placeholderMap.put("describe." + distanceName, Lazy.by(() -> String.valueOf(descriptionDistance.get())));
+        placeholderMap.put("describe." + distanceName + ".snapshot", Lazy.by(() -> (descriptionDistance.get() == 0 ? "" : "-SNAPSHOT")));
+
+        placeholderMap.put("describe.tag.version.patch.plus.describe." + distanceName, Lazy.by(() -> increase(placeholderMap.get("describe.tag.version.patch").get(), descriptionDistance.get())));
+        placeholderMap.put("describe.tag.version.patch.next.plus.describe." + distanceName, Lazy.by(() -> increase(placeholderMap.get("describe.tag.version.patch.next").get(), descriptionDistance.get())));
+
+        placeholderMap.put("describe.tag.version.label.plus.describe." + distanceName, Lazy.by(() -> increase(placeholderMap.get("describe.tag.version.label").get(), descriptionDistance.get())));
+        placeholderMap.put("describe.tag.version.label.next.plus.describe." + distanceName, Lazy.by(() -> increase(placeholderMap.get("describe.tag.version.label.next").get(), descriptionDistance.get())));
     }
 
     private Matcher matchVersion(String input) {


### PR DESCRIPTION
Hello, I'm very interested by your extension and I like the way we can configure it, however I see some use cases I'd need to resolve, so I propose a few pull requests with feature I could use for my pipelines.

This first one is to get the describe distance only if a matching tag was found. This way if I don't have a matching tag I have a 0 value I can work with to start a new version.

This is implemented by checking if the tag was found and proposing an additional distance value called `distanceOrZero`.

This is the 1st feature of 3 I need in a scenario where I want to set my RC versions on a release branch. The goal is to have a specific that acts as a marker at the start of the release branch and to use that as an expression to start incrementing RCs.