### PR TITLE
Add functions to modify the placeholder values

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,30 @@ You can configure the version and properties adjustments for specific branches a
 e.g `${env.BUILD_NUMBER:-0}` or `${env.BUILD_NUMBER:-local}`
 
 ℹ define placeholder overwrite value (placeholder is defined) like this `${name:+OVERWRITE_VALUE}`<br>
-e.g `${dirty:-SNAPSHOT}` resolves to `-SNAPSHOT` instead of `-DIRTY`
+e.g `${dirty:+-SNAPSHOT}` resolves to `-SNAPSHOT` instead of `-DIRTY`
+
+ℹ placeholder default values and overwrite values containing the `:` character can escape it by doubling it
+in case the value matches with a function name. For example, `${env.VAR:-hello::slug}` resolves to `hello:slug`
+if `env.VAR` is not defined.
+
+###### Placeholders functions
+Placeholders can contain functions with the form: `${key:functionname}` where the function `functionname` is applied to
+the value referenced by `key`.
+
+They can be combined with format placeholders and combined, e.g. `${key:-abc/def/42:slug:uppercase:next}` will give
+`ABD-DEF-43` if key is absent.
+
+Defined functions:
+- `slug`: replaces all sequences of characters that are not alphanumeric or underscore or hyphen with and hyphen and
+  eliminate duplicated hyphens from the value.
+- `slug+dot`: does the same thing as `slug` but does not replace `.` characters.
+- `word`: does the same thing as `slug` but replaces `-` and all non-alphanumeric characters with `_`.
+- `word+dot`: does the same thing as `word` but does not replace `.` characters.
+- `uppercase`: transform the value to uppercase.
+- `lowercase`: transform the value to lowercase.
+- `next`: if the value ends with a number, it is incremented, else it appends `.1` at the end of the value.
+- `incrementlast`: if the value contains a number, increments it, else does nothing, e.g. if `x` has value `rc.1-something`
+  `${x:incrementlast}` returns `rc.2-something`.
 
 ###### Placeholders
 

--- a/README.md
+++ b/README.md
@@ -177,6 +177,8 @@ Defined functions:
 - `slug`: replaces all sequences of characters that are not alphanumeric or underscore or hyphen with and hyphen and
   eliminate duplicated hyphens from the value.
 - `slug+dot`: does the same thing as `slug` but does not replace `.` characters.
+- `slug+hyphen`: does the same thing as `slug` but replaces also `_` with `-`.
+- `slug+hyphen+dot`: does the same thing as `slug+hyphen` but does not replace `.` characters.
 - `word`: does the same thing as `slug` but replaces `-` and all non-alphanumeric characters with `_`.
 - `word+dot`: does the same thing as `word` but does not replace `.` characters.
 - `uppercase`: transform the value to uppercase.

--- a/src/main/java/me/qoomon/gitversioning/commons/StringUtil.java
+++ b/src/main/java/me/qoomon/gitversioning/commons/StringUtil.java
@@ -22,6 +22,8 @@ public final class StringUtil {
         final Map<String, UnaryOperator<String>> functions = new HashMap<>();
         functions.put("slug", str -> str.replaceAll("[^\\w-]+", "-").replaceAll("-{2,}", "-"));
         functions.put("slug+dot", str -> str.replaceAll("[^\\w.-]+", "-").replaceAll("-{2,}", "-"));
+        functions.put("slug+hyphen", str -> str.replaceAll("[^a-zA-Z0-9-]+", "-").replaceAll("-{2,}", "-"));
+        functions.put("slug+hyphen+dot", str -> str.replaceAll("[^a-zA-Z0-9.-]+", "-").replaceAll("-{2,}", "-"));
         functions.put("next", StringUtil::next);
         functions.put("incrementlast", StringUtil::incrementLast);
         functions.put("uppercase", str -> str.toUpperCase(Locale.ROOT));

--- a/src/test/java/me/qoomon/gitversioning/commons/StringUtilTest.java
+++ b/src/test/java/me/qoomon/gitversioning/commons/StringUtilTest.java
@@ -86,7 +86,7 @@ class StringUtilTest {
     }
 
     @Test
-    void substituteText_function_slug() {
+    void substituteText_function_combination_slug_uppercase() {
 
         // Given
         String givenText = "${foo:+a/b:slug:uppercase}";
@@ -116,18 +116,18 @@ class StringUtilTest {
     }
 
     @Test
-    void substituteText_function_slugword() {
+    void substituteText_function_slug() {
 
         // Given
         String givenText = "${foo:slug}";
         Map<String, Supplier<String>> givenSubstitutionMap = new HashMap<>();
-        givenSubstitutionMap.put("foo", () -> "PR-56+/ii");
+        givenSubstitutionMap.put("foo", () -> "PR-56+/ii_7");
 
         // When
         String outputText = StringUtil.substituteText(givenText, givenSubstitutionMap);
 
         // Then
-        assertThat(outputText).isEqualTo("PR-56-ii");
+        assertThat(outputText).isEqualTo("PR-56-ii_7");
     }
 
     @Test
@@ -136,13 +136,43 @@ class StringUtilTest {
         // Given
         String givenText = "${foo:slug+dot}";
         Map<String, Supplier<String>> givenSubstitutionMap = new HashMap<>();
-        givenSubstitutionMap.put("foo", () -> "release/2.5");
+        givenSubstitutionMap.put("foo", () -> "my-release/2.5");
 
         // When
         String outputText = StringUtil.substituteText(givenText, givenSubstitutionMap);
 
         // Then
-        assertThat(outputText).isEqualTo("release-2.5");
+        assertThat(outputText).isEqualTo("my-release-2.5");
+    }
+
+    @Test
+    void substituteText_function_slug_hyphen() {
+
+        // Given
+        String givenText = "${foo:slug+hyphen}";
+        Map<String, Supplier<String>> givenSubstitutionMap = new HashMap<>();
+        givenSubstitutionMap.put("foo", () -> "my_release/2.5");
+
+        // When
+        String outputText = StringUtil.substituteText(givenText, givenSubstitutionMap);
+
+        // Then
+        assertThat(outputText).isEqualTo("my-release-2-5");
+    }
+
+    @Test
+    void substituteText_function_slug_hyphen_dot() {
+
+        // Given
+        String givenText = "${foo:slug+hyphen+dot}";
+        Map<String, Supplier<String>> givenSubstitutionMap = new HashMap<>();
+        givenSubstitutionMap.put("foo", () -> "my_release/2.5");
+
+        // When
+        String outputText = StringUtil.substituteText(givenText, givenSubstitutionMap);
+
+        // Then
+        assertThat(outputText).isEqualTo("my-release-2.5");
     }
 
     @Test

--- a/src/test/java/me/qoomon/gitversioning/commons/StringUtilTest.java
+++ b/src/test/java/me/qoomon/gitversioning/commons/StringUtilTest.java
@@ -85,6 +85,186 @@ class StringUtilTest {
         assertThat(outputText).isEqualTo("xxx");
     }
 
+    @Test
+    void substituteText_function_slug() {
+
+        // Given
+        String givenText = "${foo:+a/b:slug:uppercase}";
+        Map<String, Supplier<String>> givenSubstitutionMap = new HashMap<>();
+        givenSubstitutionMap.put("foo", () -> "aaa");
+
+        // When
+        String outputText = StringUtil.substituteText(givenText, givenSubstitutionMap);
+
+        // Then
+        assertThat(outputText).isEqualTo("A-B");
+    }
+
+    @Test
+    void substituteText_function_word_lowercase() {
+
+        // Given
+        String givenText = "${foo:word:lowercase}";
+        Map<String, Supplier<String>> givenSubstitutionMap = new HashMap<>();
+        givenSubstitutionMap.put("foo", () -> "PR-56+/ii");
+
+        // When
+        String outputText = StringUtil.substituteText(givenText, givenSubstitutionMap);
+
+        // Then
+        assertThat(outputText).isEqualTo("pr_56_ii");
+    }
+
+    @Test
+    void substituteText_function_slugword() {
+
+        // Given
+        String givenText = "${foo:slug}";
+        Map<String, Supplier<String>> givenSubstitutionMap = new HashMap<>();
+        givenSubstitutionMap.put("foo", () -> "PR-56+/ii");
+
+        // When
+        String outputText = StringUtil.substituteText(givenText, givenSubstitutionMap);
+
+        // Then
+        assertThat(outputText).isEqualTo("PR-56-ii");
+    }
+
+    @Test
+    void substituteText_function_slug_dot() {
+
+        // Given
+        String givenText = "${foo:slug+dot}";
+        Map<String, Supplier<String>> givenSubstitutionMap = new HashMap<>();
+        givenSubstitutionMap.put("foo", () -> "release/2.5");
+
+        // When
+        String outputText = StringUtil.substituteText(givenText, givenSubstitutionMap);
+
+        // Then
+        assertThat(outputText).isEqualTo("release-2.5");
+    }
+
+    @Test
+    void substituteText_function_word_dot() {
+
+        // Given
+        String givenText = "${foo:word+dot}";
+        Map<String, Supplier<String>> givenSubstitutionMap = new HashMap<>();
+        givenSubstitutionMap.put("foo", () -> "release/2.5");
+
+        // When
+        String outputText = StringUtil.substituteText(givenText, givenSubstitutionMap);
+
+        // Then
+        assertThat(outputText).isEqualTo("release_2.5");
+    }
+
+    @Test
+    void substituteText_function_next() {
+
+        // Given
+        String givenText = "${foo:next}";
+        Map<String, Supplier<String>> givenSubstitutionMap = new HashMap<>();
+        givenSubstitutionMap.put("foo", () -> "alpha.56-rc.12");
+
+        // When
+        String outputText = StringUtil.substituteText(givenText, givenSubstitutionMap);
+
+        // Then
+        assertThat(outputText).isEqualTo("alpha.56-rc.13");
+    }
+
+    @Test
+    void substituteText_function_next_without_number_adds_dot_1() {
+
+        // Given
+        String givenText = "${foo:next}";
+        Map<String, Supplier<String>> givenSubstitutionMap = new HashMap<>();
+        givenSubstitutionMap.put("foo", () -> "alpha.56-rc.12-abc");
+
+        // When
+        String outputText = StringUtil.substituteText(givenText, givenSubstitutionMap);
+
+        // Then
+        assertThat(outputText).isEqualTo("alpha.56-rc.12-abc.1");
+    }
+
+    @Test
+    void substituteText_function_incrementlast() {
+
+        // Given
+        String givenText = "${foo:incrementlast}";
+        Map<String, Supplier<String>> givenSubstitutionMap = new HashMap<>();
+        givenSubstitutionMap.put("foo", () -> "alpha.56-rc.12");
+
+        // When
+        String outputText = StringUtil.substituteText(givenText, givenSubstitutionMap);
+
+        // Then
+        assertThat(outputText).isEqualTo("alpha.56-rc.13");
+    }
+
+    @Test
+    void substituteText_function_incrementlast_without_number_does_nothing() {
+
+        // Given
+        String givenText = "${foo:incrementlast}";
+        Map<String, Supplier<String>> givenSubstitutionMap = new HashMap<>();
+        givenSubstitutionMap.put("foo", () -> "alpha");
+
+        // When
+        String outputText = StringUtil.substituteText(givenText, givenSubstitutionMap);
+
+        // Then
+        assertThat(outputText).isEqualTo("alpha");
+    }
+
+    @Test
+    void substituteText_function_incrementlast_without_number_at_end() {
+
+        // Given
+        String givenText = "${foo:incrementlast}";
+        Map<String, Supplier<String>> givenSubstitutionMap = new HashMap<>();
+        givenSubstitutionMap.put("foo", () -> "alpha.9-special");
+
+        // When
+        String outputText = StringUtil.substituteText(givenText, givenSubstitutionMap);
+
+        // Then
+        assertThat(outputText).isEqualTo("alpha.10-special");
+    }
+
+    @Test
+    void substituteText_function_value_escaping() {
+
+        // Given
+        String givenText = "${foo:+word::lowercase}";
+        Map<String, Supplier<String>> givenSubstitutionMap = new HashMap<>();
+        givenSubstitutionMap.put("foo", () -> "PR-56+/ii");
+
+        // When
+        String outputText = StringUtil.substituteText(givenText, givenSubstitutionMap);
+
+        // Then
+        assertThat(outputText).isEqualTo("word:lowercase");
+    }
+
+    @Test
+    void substituteText_function_value_escaping_with_function() {
+
+        // Given
+        String givenText = "${foo:+WORD:::lowercase}";
+        Map<String, Supplier<String>> givenSubstitutionMap = new HashMap<>();
+        givenSubstitutionMap.put("foo", () -> "word");
+
+        // When
+        String outputText = StringUtil.substituteText(givenText, givenSubstitutionMap);
+
+        // Then
+        assertThat(outputText).isEqualTo("word:");
+    }
+
 
     @Test
     void valueGroupMap() {


### PR DESCRIPTION
This feature adds functions to modify the placeholder values.

Originally I wanted to use the distance value from `distanceOrZero` from [this first PR](https://github.com/qoomon/maven-git-versioning-extension/pull/336) to increment a value from a custom capture group, but it was not possible.

I saw an opportunity to solve a lot of use cases by adding functions to the placeholders instead, including this one: https://github.com/qoomon/maven-git-versioning-extension/issues/246.

In my pipeline this would allow me to increment the pre-release part from RCs tags like `1.2.3-rc.2`.