### PR TITLE
Add an option to reuse values captured from ref to search a tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,17 @@ You can configure the version and properties adjustments for specific branches a
       - `<describeTagPattern>` An arbitrary regex to match tag names for git describe command
         - has to be a **full match pattern** e.g. `v.+`)
         - will override global `<describeTagPattern>` value
+        - can contain placeholders with `{{}}` delimiters that can be from env, properties, project version, or ref, but
+          not from `describe`. For example:
+          ```xml
+          <ref type="branch">
+            <pattern><![CDATA[release/(?<major>\d+)\.(?<minor>\d+)(?:\.x)?]]></pattern>
+            <describeTagPattern>\Qrelease-marker-{{ref.major}}.{{ref.minor}}\E</describeTagPattern>
+            <version>${ref.major}.${ref.minor}.0-rc.${describe.distance}-SNAPSHOT</version>
+          </ref>
+          ```
+          will first read the major and minor part of the version from the branch name, then will try to find a tag that
+          matches this specific version pieces to set the final version using describe.
       - `<describeTagFirstParent>` Enable(`true`) or disable(`false`) following only the first parent in a merge commit
         - default is `true`
           <br><br>

--- a/src/main/java/me/qoomon/gitversioning/commons/GitSituation.java
+++ b/src/main/java/me/qoomon/gitversioning/commons/GitSituation.java
@@ -3,19 +3,13 @@ package me.qoomon.gitversioning.commons;
 import org.eclipse.jgit.api.errors.GitAPIException;
 import org.eclipse.jgit.lib.ObjectId;
 import org.eclipse.jgit.lib.Repository;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
-import java.util.Map;
-import java.util.Set;
 import java.util.function.Supplier;
-import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import static java.time.Instant.EPOCH;
@@ -26,9 +20,6 @@ import static java.util.stream.Collectors.toList;
 import static me.qoomon.gitversioning.commons.GitUtil.*;
 
 public class GitSituation {
-
-    private static final Pattern PATTERN_PLACEHOLDERS_EXPRESSION = Pattern.compile("\\{\\{((?!describe\\.?)[^}]+)\\}\\}");
-    private final Logger logger = LoggerFactory.getLogger(GitSituation.class);
 
     private final Repository repository;
     private final File rootDirectory;
@@ -43,7 +34,7 @@ public class GitSituation {
 
     private Supplier<Pattern> describeTagPattern = Lazy.by(() -> Pattern.compile(".*"));
 
-    private Set<String> decribeTagPatternGroups = Collections.emptySet();
+    private String rawDescribeTagPattern = ".*";
 
     private boolean firstParent = true;
 
@@ -132,37 +123,24 @@ public class GitSituation {
         return clean.get();
     }
 
-    public void setDescribeTagPattern(String describeTagPattern, Supplier<Map<String, Supplier<String>>> placeholderMapSupplier) {
-        final String rawPattern = requireNonNull(describeTagPattern);
-        this.describeTagPattern = preProcessDescribeTagPattern(rawPattern, placeholderMapSupplier);
+    /**
+     * Returns the describeTagPattern as set in config. It may contain placeholders delimited by <code>{{}}</code>,
+     * e.g. <code>{{ref.myCaptureGroupFromRef}}</code>. In order to get placeholder resolved,
+     * {@link GitSituation#getDescribeTagPattern()} should be used.
+     *
+     * @return the raw expressing for describe tag pattern
+     */
+    public String getRawDescribeTagPattern() {
+        return rawDescribeTagPattern;
+    }
+
+    public void setRawDescribeTagPattern(String rawDescribeTagPattern) {
+        this.rawDescribeTagPattern = requireNonNull(rawDescribeTagPattern);
+    }
+
+    public void setDescribeTagPattern(Supplier<Pattern> describeTagPattern) {
+        this.describeTagPattern = requireNonNull(describeTagPattern);
         this.description = Lazy.by(this::describe);
-    }
-
-    private Supplier<Pattern> preProcessDescribeTagPattern(String describeTagPattern, Supplier<Map<String, Supplier<String>>> placeholderMapSupplier) {
-        final Matcher placeHolderMatcher = PATTERN_PLACEHOLDERS_EXPRESSION.matcher(describeTagPattern);
-        final String placeHolderStrippedPattern = placeHolderMatcher.replaceAll("");
-        decribeTagPatternGroups = StringUtil.patternGroups(Pattern.compile(placeHolderStrippedPattern));
-        return Lazy.by(() -> {
-            placeHolderMatcher.reset();
-            final StringBuffer sb = new StringBuffer();
-            while (placeHolderMatcher.find()) {
-                final String capture = placeHolderMatcher.group(1);
-                if (placeholderMapSupplier.get().containsKey(capture)) {
-                    final String value = placeholderMapSupplier.get().get(capture).get();
-                    placeHolderMatcher.appendReplacement(sb, value);
-                }
-            }
-            placeHolderMatcher.appendTail(sb);
-            final String pattern = sb.toString();
-            if (!describeTagPattern.equals(pattern)) {
-                logger.info("Computed pattern '{}' from describeTagPattern '{}'", pattern, describeTagPattern);
-            }
-            return Pattern.compile(pattern);
-        });
-    }
-
-    public Set<String> getDescribeTagPatternGroups() {
-        return decribeTagPatternGroups;
     }
 
     public Pattern getDescribeTagPattern() {

--- a/src/main/java/me/qoomon/maven/gitversioning/Configuration.java
+++ b/src/main/java/me/qoomon/maven/gitversioning/Configuration.java
@@ -48,13 +48,6 @@ public class Configuration {
 
     public Boolean describeTagFirstParent = true;
 
-    public Pattern describeTagPattern() {
-        if(describeTagPattern == null) {
-            return null;
-        }
-        return Pattern.compile(describeTagPattern);
-    }
-
     public Boolean updatePom = false;
 
     public RefPatchDescriptionList refs = new RefPatchDescriptionList();
@@ -71,13 +64,6 @@ public class Configuration {
 
         @JsonDeserialize(using = IgnoreWhitespaceDeserializer.class)
         public String describeTagPattern;
-
-        public Pattern describeTagPattern() {
-            if(describeTagPattern == null) {
-                return null;
-            }
-            return Pattern.compile(describeTagPattern);
-        }
 
         @JsonDeserialize(using = IgnoreWhitespaceDeserializer.class)
         public String version;

--- a/src/main/java/me/qoomon/maven/gitversioning/GitVersioningModelProcessor.java
+++ b/src/main/java/me/qoomon/maven/gitversioning/GitVersioningModelProcessor.java
@@ -1095,9 +1095,8 @@ public class GitVersioningModelProcessor implements ModelProcessor {
     }
 
     private Supplier<Pattern> preProcessDescribeTagPattern(String describeTagPattern, Supplier<Map<String, Supplier<String>>> placeholderMapSupplier) {
-        final Matcher placeHolderMatcher = PATTERN_PLACEHOLDERS_EXPRESSION.matcher(describeTagPattern);
         return Lazy.by(() -> {
-            placeHolderMatcher.reset();
+            final Matcher placeHolderMatcher = PATTERN_PLACEHOLDERS_EXPRESSION.matcher(describeTagPattern);
             final StringBuilder sb = new StringBuilder();
             while (placeHolderMatcher.find()) {
                 final String capture = placeHolderMatcher.group(1);

--- a/src/main/java/me/qoomon/maven/gitversioning/GitVersioningModelProcessor.java
+++ b/src/main/java/me/qoomon/maven/gitversioning/GitVersioningModelProcessor.java
@@ -8,6 +8,7 @@ import de.pdark.decentxml.Element;
 import me.qoomon.gitversioning.commons.GitDescription;
 import me.qoomon.gitversioning.commons.GitSituation;
 import me.qoomon.gitversioning.commons.Lazy;
+import me.qoomon.gitversioning.commons.StringUtil;
 import me.qoomon.maven.gitversioning.Configuration.PatchDescription;
 import me.qoomon.maven.gitversioning.Configuration.RefPatchDescription;
 import org.apache.maven.building.Source;
@@ -49,7 +50,8 @@ import static java.util.Collections.singletonList;
 import static java.util.Objects.requireNonNullElse;
 import static java.util.stream.Collectors.*;
 import static me.qoomon.gitversioning.commons.GitRefType.*;
-import static me.qoomon.gitversioning.commons.StringUtil.*;
+import static me.qoomon.gitversioning.commons.StringUtil.patternGroupValues;
+import static me.qoomon.gitversioning.commons.StringUtil.substituteText;
 import static me.qoomon.maven.gitversioning.BuildProperties.projectArtifactId;
 import static me.qoomon.maven.gitversioning.GitVersioningMojo.asPlugin;
 import static me.qoomon.maven.gitversioning.MavenUtil.*;
@@ -67,6 +69,7 @@ import static org.slf4j.LoggerFactory.getLogger;
 public class GitVersioningModelProcessor implements ModelProcessor {
 
     private static final Pattern VERSION_PATTERN = Pattern.compile(".*?(?<version>(?<core>(?<major>\\d+)(?:\\.(?<minor>\\d+)(?:\\.(?<patch>\\d+))?)?)(?:-(?<label>.*))?)|");
+    private static final Pattern PATTERN_PLACEHOLDERS_EXPRESSION = Pattern.compile("\\{\\{((?!describe\\.?)[^}]+)}}");
 
     private static final String OPTION_NAME_GIT_REF = "git.ref";
     private static final String OPTION_NAME_GIT_TAG = "git.tag";
@@ -225,15 +228,17 @@ public class GitVersioningModelProcessor implements ModelProcessor {
             return;
         }
 
-        final Supplier<Map<String, Supplier<String>>> placeholderMapSupplier =
-                Lazy.by(() -> generateGlobalFormatPlaceholderMap(gitSituation, gitVersionDetails, mavenSession));
-
         logger.info("matching ref: {} - {}", gitVersionDetails.getRefType().name(), gitVersionDetails.getRefName());
         final RefPatchDescription patchDescription = gitVersionDetails.getPatchDescription();
         logger.info("ref configuration: {} - pattern: {}", gitVersionDetails.getRefType().name(), patchDescription.pattern);
+
+        final Supplier<Map<String, Supplier<String>>> placeholderMapSupplier =
+                Lazy.by(() -> generateGlobalFormatPlaceholderMap(gitSituation, gitVersionDetails, mavenSession));
+
         if (patchDescription.describeTagPattern != null && !patchDescription.describeTagPattern.equals(".*")) {
             logger.info("  describeTagPattern: {}", patchDescription.describeTagPattern);
-            gitSituation.setDescribeTagPattern(patchDescription.describeTagPattern, placeholderMapSupplier);
+            gitSituation.setRawDescribeTagPattern(patchDescription.describeTagPattern);
+            gitSituation.setDescribeTagPattern(preProcessDescribeTagPattern(patchDescription.describeTagPattern, placeholderMapSupplier));
         }
         if (patchDescription.describeTagFirstParent != null) {
             logger.info("  describeTagFirstParent: {}", patchDescription.describeTagFirstParent);
@@ -838,6 +843,12 @@ public class GitVersioningModelProcessor implements ModelProcessor {
         return substituteText(propertyFormat, placeholderMap);
     }
 
+    private static Set<String> extractTagPatternGroups(String describeTagPattern) {
+        final Matcher placeHolderMatcher = PATTERN_PLACEHOLDERS_EXPRESSION.matcher(describeTagPattern);
+        final String placeHolderStrippedPattern = placeHolderMatcher.replaceAll("");
+        return StringUtil.patternGroups(Pattern.compile(placeHolderStrippedPattern));
+    }
+
     private Map<String, Supplier<String>> generateFormatPlaceholderMap(String projectVersion) {
         final Map<String, Supplier<String>> placeholderMap = new HashMap<>(globalFormatPlaceholderMap);
 
@@ -981,7 +992,7 @@ public class GitVersioningModelProcessor implements ModelProcessor {
         // describe tag pattern groups
         final Lazy<Map<String, String>> describeTagPatternValues = Lazy.by(
                 () -> patternGroupValues(gitSituation.getDescribeTagPattern(), descriptionTag.get()));
-        for (String groupName : gitSituation.getDescribeTagPatternGroups()) {
+        for (String groupName : extractTagPatternGroups(gitSituation.getRawDescribeTagPattern())) {
             final var placeholderKey = "describe.tag." + groupName;
             // ensure no placeholder overwrites
             if (placeholderMap.containsKey(placeholderKey)) {
@@ -1081,6 +1092,27 @@ public class GitVersioningModelProcessor implements ModelProcessor {
         }
 
         return false;
+    }
+
+    private Supplier<Pattern> preProcessDescribeTagPattern(String describeTagPattern, Supplier<Map<String, Supplier<String>>> placeholderMapSupplier) {
+        final Matcher placeHolderMatcher = PATTERN_PLACEHOLDERS_EXPRESSION.matcher(describeTagPattern);
+        return Lazy.by(() -> {
+            placeHolderMatcher.reset();
+            final StringBuilder sb = new StringBuilder();
+            while (placeHolderMatcher.find()) {
+                final String capture = placeHolderMatcher.group(1);
+                if (placeholderMapSupplier.get().containsKey(capture)) {
+                    final String value = placeholderMapSupplier.get().get(capture).get();
+                    placeHolderMatcher.appendReplacement(sb, value);
+                }
+            }
+            placeHolderMatcher.appendTail(sb);
+            final String pattern = sb.toString();
+            if (!describeTagPattern.equals(pattern)) {
+                logger.info("Computed pattern '{}' from describeTagPattern '{}'", pattern, describeTagPattern);
+            }
+            return Pattern.compile(pattern);
+        });
     }
 
     // ---- determine related projects ---------------------------------------------------------------------------------


### PR DESCRIPTION
I have this use case where I have branches containing a part of the version, but I need to resolve the rest of the version from the previous tags.

For example, `release/2.3` will set the base version to `2.3.0` but on this branch, the release is still in preparation, so I need to check for specific tags that match the version from the branch (`2.3.0-rc.1` and other increments starting with `2.3`) in order to not mix any other tag versions with the release to go.

I implemented a way to put placeholders in the `describeTagPattern`  to find the right tags, like:
```xml
<ref type="branch">
  <pattern><![CDATA[release/(?<major>\d+)\.(?<minor>\d+)(?:\.x)?]]></pattern>
  <describeTagPattern>\Qrelease-marker-{{ref.major}}.{{ref.minor}}\E</describeTagPattern>
  <version>${ref.major}.${ref.minor}.0-rc.${describe.distance}-SNAPSHOT</version>
</ref>
```

The idea is that `{{` is normally not valid for regex if not escaped. If the key found is not part of the map, the placeholder is left untouched.