### PR TITLE
feat(StringUtil): implement format placeholders closer to _posix parameter expansion_ - i.e. implement optional colon

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,11 +156,11 @@ You can configure the version and properties adjustments for specific branches a
 
 ℹ Final `version` will be slugified automatically, so no need to use `${….slug}` placeholders in `<version>` format.
 
-ℹ define placeholder default value (placeholder is not defined) like this `${name:-DEFAULT_VALUE}`<br>
-e.g `${env.BUILD_NUMBER:-0}` or `${env.BUILD_NUMBER:-local}`
+ℹ define placeholder default value (placeholder is not defined '-' or empty ':-') like this `${name:-DEFAULT_VALUE}`<br>
+e.g `${env.BUILD_NUMBER-0}` or `${env.BUILD_NUMBER:-local}`
 
-ℹ define placeholder overwrite value (placeholder is defined) like this `${name:+OVERWRITE_VALUE}`<br>
-e.g `${dirty:-SNAPSHOT}` resolves to `-SNAPSHOT` instead of `-DIRTY`
+ℹ define placeholder overwrite value (placeholder is defined '+' and non-empty ':+' ) like this `${name:+OVERWRITE_VALUE}`<br>
+e.g `${dirty:+SNAPSHOT}` resolves to `-SNAPSHOT` instead of `-DIRTY`
 
 ###### Placeholders
 

--- a/src/main/java/me/qoomon/gitversioning/commons/StringUtil.java
+++ b/src/main/java/me/qoomon/gitversioning/commons/StringUtil.java
@@ -12,7 +12,7 @@ public final class StringUtil {
 
     public static String substituteText(String text, Map<String, Supplier<String>> replacements) {
         StringBuffer result = new StringBuffer();
-        Pattern placeholderPattern = Pattern.compile("\\$\\{(?<key>[^}:]+)(?::(?<modifier>[-+])(?<value>[^}]*))?}");
+        Pattern placeholderPattern = Pattern.compile("\\$\\{(?<key>[^}:]+)(?<modifier>:?[-+])?(?<value>[^}]*)?}");
         Matcher placeholderMatcher = placeholderPattern.matcher(text);
         while (placeholderMatcher.find()) {
             String placeholderKey = placeholderMatcher.group("key");
@@ -24,6 +24,12 @@ public final class StringUtil {
                     replacement = placeholderMatcher.group("value");
                 }
                 if (placeholderModifier.equals("+") && replacement != null) {
+                    replacement = placeholderMatcher.group("value");
+                }
+                if (placeholderModifier.equals(":-") && (replacement == null || replacement.isEmpty())) {
+                    replacement = placeholderMatcher.group("value");
+                }
+                if (placeholderModifier.equals(":+") && replacement != null && !replacement.isEmpty()) {
                     replacement = placeholderMatcher.group("value");
                 }
             }


### PR DESCRIPTION
My use case is: If branch name is develop, version should be develop-SNAPSHOT. If branch name is feature/JIRA-12345, version should be \~JIRA-12345-SNAPSHOT, so it is alphabeticaly always later (newer). The tilda should be added only if prefix "feature/" is present i.e. ${prefix:+~}.

The problem is, that even if prefix is not defined current implementation creates ${prefix} with empty string, so the overwriting happen. My PR adds possibility to treat empty string as variable not defined.