### PR TITLE
Added support for plugin with dependency from related project

### DIFF
--- a/src/main/java/me/qoomon/maven/gitversioning/GitVersioningModelProcessor.java
+++ b/src/main/java/me/qoomon/maven/gitversioning/GitVersioningModelProcessor.java
@@ -427,7 +427,7 @@ public class GitVersioningModelProcessor implements ModelProcessor {
         // plugins section
         {
             List<Plugin> plugins = build.getPlugins();
-			List<Plugin> relatedPlugins = filterRelatedPlugins(plugins);
+            List<Plugin> relatedPlugins = filterRelatedPlugins(plugins);
             if (!relatedPlugins.isEmpty()) {
                 if (logger.isDebugEnabled()) {
                     logger.debug(sectionLogHeader("plugins", model));
@@ -472,19 +472,19 @@ public class GitVersioningModelProcessor implements ModelProcessor {
     }
 
 
-	private void updatePluginDependencyVersions(ModelBase model, String versionFormat, List<Plugin> plugins) {
-		List<Dependency> pluginDepsList = filterRelatedDependencies(plugins.stream().map(plugin -> plugin.getDependencies().stream()).flatMap(s -> s).toList());
-		
+    private void updatePluginDependencyVersions(ModelBase model, String versionFormat, List<Plugin> plugins) {
+        List<Dependency> pluginDepsList = filterRelatedDependencies(plugins.stream().map(plugin -> plugin.getDependencies().stream()).flatMap(s -> s).toList());
+        
 
-		if (!pluginDepsList.isEmpty()) {
-		    if (true) {
-		        logger.info(sectionLogHeader("plugins deps", model));
-		    }
-		    for (Dependency dep : pluginDepsList) {
-		        updateVersion(dep, versionFormat);
-		    }
-		}
-	}
+        if (!pluginDepsList.isEmpty()) {
+            if (true) {
+                logger.info(sectionLogHeader("plugins deps", model));
+            }
+            for (Dependency dep : pluginDepsList) {
+                updateVersion(dep, versionFormat);
+            }
+        }
+    }
 
     private void updateVersion(Plugin plugin, String versionFormat) {
         if (plugin.getVersion() != null) {
@@ -1362,9 +1362,9 @@ public class GitVersioningModelProcessor implements ModelProcessor {
             }
             
             Element dependenciesElement = pluginElement.getChild("dependencies");
-			List<Dependency> dependencies = plugin.getDependencies();
-			if (!dependencies.isEmpty() && dependenciesElement != null) {
-				updateDependencyVersions(dependenciesElement, dependencies);
+            List<Dependency> dependencies = plugin.getDependencies();
+            if (!dependencies.isEmpty() && dependenciesElement != null) {
+                updateDependencyVersions(dependenciesElement, dependencies);
             }
         });
     }

--- a/src/main/java/me/qoomon/maven/gitversioning/GitVersioningModelProcessor.java
+++ b/src/main/java/me/qoomon/maven/gitversioning/GitVersioningModelProcessor.java
@@ -426,8 +426,7 @@ public class GitVersioningModelProcessor implements ModelProcessor {
         }
         // plugins section
         {
-            List<Plugin> plugins = build.getPlugins();
-            List<Plugin> relatedPlugins = filterRelatedPlugins(plugins);
+            List<Plugin> relatedPlugins = filterRelatedPlugins(build.getPlugins());
             if (!relatedPlugins.isEmpty()) {
                 if (logger.isDebugEnabled()) {
                     logger.debug(sectionLogHeader("plugins", model));
@@ -437,7 +436,7 @@ public class GitVersioningModelProcessor implements ModelProcessor {
                 }
             }
             
-            updatePluginDependencyVersions(model, versionFormat, plugins);
+            updatePluginDependencyVersions(model, versionFormat, build.getPlugins());
         }
 
         // plugin management section

--- a/src/main/java/me/qoomon/maven/gitversioning/GitVersioningModelProcessor.java
+++ b/src/main/java/me/qoomon/maven/gitversioning/GitVersioningModelProcessor.java
@@ -31,10 +31,6 @@ import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.*;
 import java.util.Map.Entry;
-import java.util.NoSuchElementException;
-import java.util.Objects;
-import java.util.Properties;
-import java.util.Set;
 import java.util.function.BiConsumer;
 import java.util.function.Supplier;
 import java.util.regex.Matcher;
@@ -430,7 +426,8 @@ public class GitVersioningModelProcessor implements ModelProcessor {
         }
         // plugins section
         {
-            List<Plugin> relatedPlugins = filterRelatedPlugins(build.getPlugins());
+            List<Plugin> plugins = build.getPlugins();
+			List<Plugin> relatedPlugins = filterRelatedPlugins(plugins);
             if (!relatedPlugins.isEmpty()) {
                 if (logger.isDebugEnabled()) {
                     logger.debug(sectionLogHeader("plugins", model));
@@ -439,6 +436,8 @@ public class GitVersioningModelProcessor implements ModelProcessor {
                     updateVersion(plugin, versionFormat);
                 }
             }
+            
+            updatePluginDependencyVersions(model, versionFormat, plugins);
         }
 
         // plugin management section
@@ -453,6 +452,8 @@ public class GitVersioningModelProcessor implements ModelProcessor {
                     updateVersion(plugin, versionFormat);
                 }
             }
+            
+            updatePluginDependencyVersions(model, versionFormat, pluginManagement.getPlugins());
         }
 
         // reporting section
@@ -469,6 +470,21 @@ public class GitVersioningModelProcessor implements ModelProcessor {
             }
         }
     }
+
+
+	private void updatePluginDependencyVersions(ModelBase model, String versionFormat, List<Plugin> plugins) {
+		List<Dependency> pluginDepsList = filterRelatedDependencies(plugins.stream().map(plugin -> plugin.getDependencies().stream()).flatMap(s -> s).toList());
+		
+
+		if (!pluginDepsList.isEmpty()) {
+		    if (true) {
+		        logger.info(sectionLogHeader("plugins deps", model));
+		    }
+		    for (Dependency dep : pluginDepsList) {
+		        updateVersion(dep, versionFormat);
+		    }
+		}
+	}
 
     private void updateVersion(Plugin plugin, String versionFormat) {
         if (plugin.getVersion() != null) {
@@ -1343,6 +1359,12 @@ public class GitVersioningModelProcessor implements ModelProcessor {
             Element pluginVersionElement = pluginElement.getChild("version");
             if (pluginVersionElement != null) {
                 pluginVersionElement.setText(plugin.getVersion());
+            }
+            
+            Element dependenciesElement = pluginElement.getChild("dependencies");
+			List<Dependency> dependencies = plugin.getDependencies();
+			if (!dependencies.isEmpty() && dependenciesElement != null) {
+				updateDependencyVersions(dependenciesElement, dependencies);
             }
         });
     }

--- a/src/test/java/me/qoomon/maven/gitversioning/GitVersioningExtensionIT.java
+++ b/src/test/java/me/qoomon/maven/gitversioning/GitVersioningExtensionIT.java
@@ -201,10 +201,10 @@ class GitVersioningExtensionIT {
             dependency.setVersion(pomModel.getVersion());
             plugin.setArtifactId("maven-enforcer-plugin");
             plugin.addDependency(dependency);            
-			Build build = new Build();
-			build.addPlugin(plugin);
-			pomModel.setBuild(build);
-			
+            Build build = new Build();
+            build.addPlugin(plugin);
+            pomModel.setBuild(build);
+            
             writeModel(projectDir.resolve("pom.xml").toFile(), pomModel);
             writeExtensionsFile(projectDir);
             writeExtensionConfigFile(projectDir, new Configuration() {{

--- a/src/test/java/me/qoomon/maven/gitversioning/GitVersioningExtensionIT.java
+++ b/src/test/java/me/qoomon/maven/gitversioning/GitVersioningExtensionIT.java
@@ -5,10 +5,13 @@ import com.fasterxml.jackson.dataformat.xml.XmlMapper;
 import me.qoomon.gitversioning.commons.GitRefType;
 import me.qoomon.maven.gitversioning.Configuration.PatchDescription;
 import me.qoomon.maven.gitversioning.Configuration.RefPatchDescription;
+
+import org.apache.maven.model.Build;
 import org.apache.maven.model.Dependency;
 import org.apache.maven.model.DependencyManagement;
 import org.apache.maven.model.Model;
 import org.apache.maven.model.Parent;
+import org.apache.maven.model.Plugin;
 import org.apache.maven.shared.verifier.VerificationException;
 import org.apache.maven.shared.verifier.Verifier;
 import org.eclipse.jgit.api.Git;
@@ -180,6 +183,49 @@ class GitVersioningExtensionIT {
 
             Model gitVersionedPomModel = readModel(projectDir.resolve(GIT_VERSIONING_POM_NAME).toFile());
             assertThat(gitVersionedPomModel.getVersion()).isEqualTo(expectedVersion);
+        }
+    }
+    @Test
+    void branchVersioningPluginWithDeps() throws Exception {
+
+        try (Git git = Git.init().setInitialBranch("feature/test").setDirectory(projectDir.toFile()).call()) {
+            // Given
+            git.commit().setMessage("initial commit").setAllowEmpty(true).call();
+            
+            
+            // Put there just some dummy plugin with some dummy dependency
+            Plugin plugin = new Plugin();            
+            Dependency dependency = new Dependency();
+            dependency.setGroupId(pomModel.getGroupId());
+            dependency.setArtifactId(pomModel.getArtifactId());
+            dependency.setVersion(pomModel.getVersion());
+            plugin.setArtifactId("maven-enforcer-plugin");
+            plugin.addDependency(dependency);            
+			Build build = new Build();
+			build.addPlugin(plugin);
+			pomModel.setBuild(build);
+			
+            writeModel(projectDir.resolve("pom.xml").toFile(), pomModel);
+            writeExtensionsFile(projectDir);
+            writeExtensionConfigFile(projectDir, new Configuration() {{
+                refs.list.add(createBranchVersionDescription());
+            }});
+            
+            // When
+            Verifier verifier = getVerifier(projectDir);
+            verifier.addCliArgument("verify");
+            verifier.execute();
+
+            // Then
+            System.err.println(String.join("\n", verifier.loadFile(verifier.getBasedir(), verifier.getLogFileName(), false)));
+            verifier.verifyErrorFreeLog();
+            String expectedVersion = "feature-test-gitVersioning";
+            verifier.verifyTextInLog("Building " + pomModel.getArtifactId() + " " + expectedVersion);
+
+            System.out.println(new String(Files.readAllBytes(projectDir.resolve(GIT_VERSIONING_POM_NAME))));
+            Model gitVersionedPomModel = readModel(projectDir.resolve(GIT_VERSIONING_POM_NAME).toFile());
+            assertThat(gitVersionedPomModel.getVersion()).isEqualTo(expectedVersion);
+            assertThat(gitVersionedPomModel.getBuild().getPlugins().get(0).getDependencies().get(0).getVersion()).isEqualTo(expectedVersion);
         }
     }
 


### PR DESCRIPTION
Currently I have a multi-module project where I use jsonschema2pojo-maven-plugin to generate pojo classes from JSON schemas and I needed to add there a customAnotator from my another module.

Here is a part of the build plugin configuration:

       <plugin>
        <groupId>io.github.jiri-meluzin</groupId>
        <artifactId>jsonschema2pojo-maven-plugin</artifactId>
        <version>1.2.2-VFGenericsFix</version>
        <dependencies>
          <dependency>
            <groupId>xxxx.yaml</groupId>
            <artifactId>annotator</artifactId>
            <version>${project.version}</version>
          </dependency>
        </dependencies>
        <configuration>
          <customAnnotator>xxxx.yaml.annotator.HideObjectsWithDefaultValue</customAnnotator>
          ....
          <targetPackage>xxxx.config.globalconfig</targetPackage>
          <targetVersion>11</targetVersion>
        </configuration>
        <executions>
          <?m2e execute onConfiguration,onIncremental?>
          <execution>
            <goals>
              <goal>generate</goal>
            </goals>
          </execution>
        </executions>
      </plugin>
      
      
So what I struggle is to update the version of the dependency:

          <dependency>
            <groupId>xxxx.yaml</groupId>
            <artifactId>annotator</artifactId>
            <version>${project.version}</version>
          </dependency>

=>


          <dependency>
            <groupId>xxxx.yaml</groupId>
            <artifactId>annotator</artifactId>
            <version>feature.xyz</version>
          </dependency>

The PullRequest solved the issue. So kindly please to merge the PR :) 