### PR TITLE
feat: added commandline option to define config file name

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,6 +277,12 @@ e.g `${dirty:+SNAPSHOT}` resolves to `-SNAPSHOT` instead of `-DIRTY`
 
 ### Parameters & Environment Variables
 
+- Set configuration Filename
+  - **Environment Variables**
+  - `export VERSIONING_CONFIG_FILE=myConfig.xml`
+  - **Command Line Parameters**
+  - `mvn … -Dversioning.configFile=myConfig.xml`
+
 - Disable Extension
     - **Environment Variables**
      - `export VERSIONING_DISABLE=true`

--- a/src/main/java/me/qoomon/maven/gitversioning/GitVersioningModelProcessor.java
+++ b/src/main/java/me/qoomon/maven/gitversioning/GitVersioningModelProcessor.java
@@ -69,6 +69,7 @@ public class GitVersioningModelProcessor implements ModelProcessor {
     private static final String OPTION_NAME_GIT_BRANCH = "git.branch";
     private static final String OPTION_NAME_DISABLE = "versioning.disable";
     private static final String OPTION_UPDATE_POM = "versioning.updatePom";
+    private static final String OPTION_CONFIG_FILE_NAME = "versioning.configFile";
 
     static final String GIT_VERSIONING_POM_NAME = ".git-versioned-pom.xml";
 
@@ -169,7 +170,13 @@ public class GitVersioningModelProcessor implements ModelProcessor {
         logger.debug("pom file: {}", pomFile);
         mvnDirectory = findMvnDirectory(pomFile);
         logger.debug(".mvn directory: {}", mvnDirectory);
-        final File configFile = new File(mvnDirectory, projectArtifactId() + ".xml");
+
+        String configFileName = getCommandOption(OPTION_CONFIG_FILE_NAME);
+        if(configFileName == null){
+            configFileName = projectArtifactId() + ".xml";
+        }
+
+        final File configFile = new File(mvnDirectory, configFileName);
         logger.debug("read config from {}", configFile);
         config = readConfig(configFile);
 


### PR DESCRIPTION
We need to be able to use a slightly modified configuration in our CI/CD pipeline. Therefore, we added an option to define the configuration file name via command-line arguments / environment variables