### PR TITLE
fix: Repository should not be dirty with only untracked files

### DIFF
--- a/src/main/java/me/qoomon/gitversioning/commons/GitSituation.java
+++ b/src/main/java/me/qoomon/gitversioning/commons/GitSituation.java
@@ -159,7 +159,7 @@ public class GitSituation {
     }
 
     private boolean clean() throws GitAPIException {
-        return GitUtil.status(repository).isClean();
+        return !GitUtil.status(repository).hasUncommittedChanges();
     }
 
     private GitDescription describe() throws IOException {


### PR DESCRIPTION
Dirty repository status resolution used by `git describe --dirty` is that the repository is marked as dirty only when there are some 'local changes'.
[git describe](https://git-scm.com/docs/git-describe)

> Describe the state of the working tree. When the working tree matches HEAD, the output is the same as "git describe HEAD". If the working tree has local modification "-dirty" is appended to it. If a repository is corrupt and Git cannot determine if there is local modification, Git will error out, unless ‘--broken’ is given, which appends the suffix "-broken" instead.

If the repository contains only untracked files, `git describe --dirty` does not add the `-dirty` suffix, but this extension does, which is not correct.