### PR TITLE
build(deps): bump to org.eclipse.jgit:org.eclipse.jgit from 6.10.1.202505221210-r to 7.5.0.202512021534-r

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@
         <dependency>
             <groupId>org.eclipse.jgit</groupId>
             <artifactId>org.eclipse.jgit</artifactId>
-            <version>6.10.1.202505221210-r</version>
+            <version>7.5.0.202512021534-r</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
The new version of jgit fixes an error when using this plugin with a worktree of a bare repository.