### PR TITLE
#410 - fix for worktree in case of packed refs

### DIFF
--- a/src/main/java/me/qoomon/gitversioning/commons/GitUtil.java
+++ b/src/main/java/me/qoomon/gitversioning/commons/GitUtil.java
@@ -35,7 +35,25 @@ public final class GitUtil {
     public static String NO_COMMIT = "0000000000000000000000000000000000000000";
 
     public static Status status(Repository repository) throws GitAPIException {
-        return Git.wrap(repository).status().call();
+        try {
+            return Git.wrap(repository).status().call();
+        } catch (NoWorkTreeException ex) {
+            return worktreesFix_status(repository);
+        }
+    }
+
+    private static Status worktreesFix_status(Repository repository) throws GitAPIException {
+        try {
+            try (Repository worktreeRepository = new FileRepositoryBuilder()
+                    .setGitDir(repository.getDirectory())
+                    .setWorkTree(worktreesFix_getWorkTree(repository))
+                    .build();
+                 Git worktreeGit = new Git(worktreeRepository)) {
+                return worktreeGit.status().call();
+            }
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     public static String branch(Repository repository) throws IOException {
@@ -167,23 +185,22 @@ public final class GitUtil {
             repository.getWorkTree();
             return repository.resolve(HEAD);
         } catch (NoWorkTreeException e) {
-            File headFile = new File(repository.getDirectory(), "HEAD");
+            File headFile = new File(repository.getDirectory(), HEAD);
             if (!headFile.exists()) {
                 throw e;
             }
 
+            Repository commonRepository = worktreesFix_getCommonRepository(repository);
             String head = Files.readAllLines(headFile.toPath()).get(0);
             if (head.startsWith("ref:")) {
                 String refPath = head.replaceFirst("^ref: *", "");
-
-                File commonDirFile = new File(repository.getDirectory(), "commondir");
-                String commonDirPath = Files.readAllLines(commonDirFile.toPath()).get(0);
-                File commonGitDir = new File(repository.getDirectory(), commonDirPath);
-
-                File refFile = new File(commonGitDir, refPath);
-                head = Files.readAllLines(refFile.toPath()).get(0);
+                ObjectId resolvedRef = commonRepository.resolve(refPath);
+                if (resolvedRef == null) {
+                    throw new IOException("Cannot resolve head ref '" + refPath + "'");
+                }
+                return resolvedRef;
             }
-            return repository.resolve(head);
+            return commonRepository.resolve(head);
         }
     }
 }

--- a/src/test/java/me/qoomon/gitversioning/commons/GitUtilTest.java
+++ b/src/test/java/me/qoomon/gitversioning/commons/GitUtilTest.java
@@ -5,12 +5,15 @@ import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.api.Status;
 import org.eclipse.jgit.api.errors.GitAPIException;
 import org.eclipse.jgit.lib.ObjectId;
+import org.eclipse.jgit.lib.Repository;
 import org.eclipse.jgit.revwalk.RevCommit;
+import org.eclipse.jgit.storage.file.FileRepositoryBuilder;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.regex.Pattern;
@@ -166,6 +169,40 @@ class GitUtilTest {
 
         // then
         assertThat(tags).containsExactlyInAnyOrder(givenTagName);
+    }
+
+    @Test
+    void worktreesFix_resolveHead_handlesPackedRefs() throws Exception {
+
+        // given
+        Git git = Git.init().setInitialBranch(MASTER).setDirectory(tempDir.toFile()).call();
+        RevCommit givenCommit = git.commit().setMessage("initial commit").setAllowEmpty(true).call();
+        String givenBranch = "fixing/franco-2.1.5";
+        git.branchCreate().setName(givenBranch).setStartPoint(givenCommit).call();
+
+        Path gitDir = tempDir.resolve(".git");
+        Path branchRef = gitDir.resolve("refs").resolve("heads").resolve(givenBranch);
+        assertThat(branchRef).exists();
+
+        Path packedRefs = gitDir.resolve("packed-refs");
+        Files.writeString(packedRefs, givenCommit.getName() + " refs/heads/" + givenBranch + System.lineSeparator());
+        Files.delete(branchRef);
+
+        Path worktreeGitDir = gitDir.resolve("worktrees").resolve("feature");
+        Files.createDirectories(worktreeGitDir);
+        Files.writeString(worktreeGitDir.resolve("HEAD"), "ref: refs/heads/" + givenBranch + System.lineSeparator());
+        Files.writeString(worktreeGitDir.resolve("commondir"), "../.." + System.lineSeparator());
+
+        try (Repository worktreeRepository = new FileRepositoryBuilder()
+                .setGitDir(worktreeGitDir.toFile())
+                .build()) {
+
+            // when
+            ObjectId head = GitUtil.worktreesFix_resolveHead(worktreeRepository);
+
+            // then
+            assertThat(head).isEqualTo(givenCommit.toObjectId());
+        }
     }
 
     private static ObjectId head(Git git) throws IOException {


### PR DESCRIPTION
## Summary
1. Handle `NoWorkTreeException` by reopening the actual worktree repository before running `status()` so worktree builds no longer crash when checking cleanliness.
2. Resolve worktree `HEAD` via the common repository (including packed refs) to avoid missing-ref errors.
3. Add a regression test that simulates a packed-ref worktree to verify `worktreesFix_resolveHead` returns the correct commit.

## Testing
- `./mvnw package install`
- `./mvnw failsafe:integration-test`
- Run my project build on main git directory and on worktree
