### PR TITLE
feat: support 4-segment tag versions and add version.next placeholder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,43 @@
 
 # Changelog
 
+## 9.12.0
+
+##### Features
+- Support 4-segment tag versions (e.g. `3.0.28.1`). New placeholders:
+  - `${describe.tag.version.build}`, `${describe.tag.version.build.next}`
+  - `${describe.tag.version.build.plus.describe.distance}`, `${describe.tag.version.build.next.plus.describe.distance}`
+  - `${version.build}`, `${version.build.next}`
+- Shape-aware version-increment placeholders that pick the right segment based on the parsed version's shape:
+  - `${describe.tag.version.next}` — one numeric segment of the tag bumped by 1. Bumps the *trailing*
+    digits of the label if a label is present (`RC1` → `RC2`, `RC10` → `RC11`); a label with no trailing
+    digits is treated as having `0` at the end (`alpha` → `alpha1`); otherwise bumps the rightmost
+    numeric core component (build → patch → minor → major).
+    - `1.2.3 → 1.2.4`, `1.2.3.4 → 1.2.3.5`
+    - `1.2.3-RC1 → 1.2.3-RC2` (standard SemVer pre-release progression)
+    - `1.2.3-alpha → 1.2.3-alpha1`
+    - `RC1-final → RC1-final1` (only *trailing* digits — not `RC2-final`).
+  - `${version.next}` — same semantics applied to the project's `<version>`.
+
+  Note: this is strictly more capable than `${...label.next}` for RC-style labels — the latter calls
+  `Long.parseLong` on the entire label and crashes on `RC1`.
+
+##### Behavior changes
+- `${describe.tag.version}` now includes the optional 4th `.build` segment when the matched tag has one.
+  Previously, for a tag like `3.0.28.1`, `${describe.tag.version}` returned `3.0.28` (silently dropping the 4th segment).
+  After this change it returns `3.0.28.1`. 3-segment tags are unaffected.
+  `${version}` itself is unchanged — it returns the raw project `<version>` and never went through the regex.
+
+##### Migration
+- The new `version.build` and `version.next` placeholders reserve the group names `build` and `next` inside
+  `<projectVersionPattern>`. If you previously defined a capture group with either name there, the extension
+  will now throw an `IllegalArgumentException` at startup ("project version pattern capture group can not be
+  named '…', because this would overwrite extension placeholder ${version.…}"). Rename the group to resolve.
+  (Named groups in `<describeTagPattern>` and `<ref>` patterns are unaffected — they use separate prefixes
+  `describe.tag.` and `ref.` respectively, so a `(?<build>…)` or `(?<next>…)` there is still valid.)
+
+Fixes [#412](https://github.com/qoomon/maven-git-versioning-extension/issues/412).
+
 ## 9.11.0
 - add option to configure config file location
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ create or update `${rootProjectDir}/.mvn/extensions.xml` file
     <extension>
         <groupId>me.qoomon</groupId>
         <artifactId>maven-git-versioning-extension</artifactId>
-        <version>9.11.0</version>
+        <version>9.12.0</version>
     </extension>
 
 </extensions>
@@ -175,8 +175,16 @@ e.g `${dirty:+SNAPSHOT}` resolves to `-SNAPSHOT` instead of `-DIRTY`
     - `${version.minor.next}` the `${version.minor}` increased by 1 e.g. '3'
   - `${version.patch}` the patch version component of `${version}` e.g. '3'
     - `${version.patch.next}` the `${version.patch}` increased by 1 e.g. '4'
+  - `${version.build}` the build version component (optional 4th dot-segment) of `${version}` e.g. '4'
+    - `${version.build.next}` the `${version.build}` increased by 1 e.g. '5'
   - `${version.label}` the version label of `${version}` e.g. 'SNAPSHOT'
     - `${version.label.prefixed}` like `${version.label}` with label separator e.g. '-SNAPSHOT'
+  - `${version.next}` `${version}` with one numeric segment bumped by 1.
+    Bumps the trailing numeric suffix of the label if a label is present (`RC1` → `RC2`); a label with no
+    trailing numeric is treated as having `0` at the end (`alpha` → `alpha1`); otherwise bumps the
+    rightmost numeric core component (build → patch → minor → major).
+    Only *trailing* digits of the label are considered — `RC1-final` bumps to `RC1-final1`, not `RC2-final`.
+    e.g. '1.2.3' → '1.2.4', '1.2.3.4' → '1.2.3.5', '1.2.3-RC1' → '1.2.3-RC2', '1.2.3-alpha' → '1.2.3-alpha1'
 - Project Version Pattern Groups
   - Content of regex groups in `<projectVersionPattern>` can be addressed like this:
   - `${version.GROUP_NAME}`
@@ -239,7 +247,7 @@ e.g `${dirty:+SNAPSHOT}` resolves to `-SNAPSHOT` instead of `-DIRTY`
 - `${describe.distance}` The distance count to last matching tag
 - `${describe.distance.snapshot}` Empty string on matching tag, `-SNAPSHOT` if `describe.distance > 0` 
 - `${describe.tag}` The matching tag of `git describe`
-  - `${describe.tag.version}` the tag version determined by regex `(?<version>(?<core>(?<major>\d+)(?:\.(?<minor>\d+)(?:\.(?<patch>\d+))?)?)(?:-(?<label>.*))?)`
+  - `${describe.tag.version}` the tag version determined by regex `(?<version>(?<core>(?<major>\d+)(?:\.(?<minor>\d+)(?:\.(?<patch>\d+))?)?)(?:\.(?<build>\d+))?(?:-(?<label>.*))?)`
     - `${describe.tag.version.core}` the core version component of `${describe.tag.version}` e.g. '1.2.3' 
     - `${describe.tag.version.major}` the major version component of `${describe.tag.version}` e.g. '1'
       - `${describe.tag.version.major.next}` the `${describe.tag.version.major}` increased by 1 e.g. '2'
@@ -249,10 +257,20 @@ e.g `${dirty:+SNAPSHOT}` resolves to `-SNAPSHOT` instead of `-DIRTY`
       - `${describe.tag.version.patch.next}` the `${describe.tag.version.patch}` increased by 1 e.g. '4'
       - `${describe.tag.version.patch.plus.describe.distance}` the `${describe.tag.version.patch}` increased by `${describe.distance}` e.g. '2'
       - `${describe.tag.version.patch.next.plus.describe.distance}` the `${describe.tag.version.patch.next}` increased by `${describe.distance}` e.g. '3'
+    - `${describe.tag.version.build}` the build version component (optional 4th dot-segment) of `${describe.tag.version}` e.g. '4'
+      - `${describe.tag.version.build.next}` the `${describe.tag.version.build}` converted to an integer and increased by 1 e.g. '5'
+      - `${describe.tag.version.build.plus.describe.distance}` the `${describe.tag.version.build}` increased by `${describe.distance}` e.g. '6'
+      - `${describe.tag.version.build.next.plus.describe.distance}` the `${describe.tag.version.build.next}` increased by `${describe.distance}` e.g. '7'
     - `${describe.tag.version.label}` the label version component of `${describe.tag.version}` e.g. 'SNAPSHOT'
       - `${describe.tag.version.label.next}` the `${describe.tag.version.label}` converted to an integer and increased by 1 e.g. '6'
       - `${describe.tag.version.label.plus.describe.distance}` the `${describe.tag.version.label}` increased by `${describe.distance}` e.g. '2'
       - `${describe.tag.version.label.next.plus.describe.distance}` the `${describe.tag.version.label.next}` increased by `${describe.distance}` e.g. '3'
+  - `${describe.tag.version.next}` `${describe.tag.version}` with one numeric segment bumped by 1.
+    Bumps the trailing numeric suffix of the label if a label is present (`RC1` → `RC2`); a label with no
+    trailing numeric is treated as having `0` at the end (`alpha` → `alpha1`); otherwise bumps the
+    rightmost numeric core component (build → patch → minor → major).
+    Only *trailing* digits of the label are considered — `RC1-final` bumps to `RC1-final1`, not `RC2-final`.
+    e.g. '1.2.3' → '1.2.4', '1.2.3.4' → '1.2.3.5', '1.2.3-RC1' → '1.2.3-RC2', '1.2.3-alpha' → '1.2.3-alpha1'
 - Describe Tag Pattern Groups
     - Content of regex groups in `<describeTagPattern>` can be addressed like this:
     - `${describe.tag.GROUP_NAME}` `${describe.tag.GROUP_NAME.slug}`

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>me.qoomon</groupId>
     <artifactId>maven-git-versioning-extension</artifactId>
-    <version>9.11.0</version>
+    <version>9.12.0</version>
     <packaging>maven-plugin</packaging>
 
     <name>Maven Git Versioning Extension</name>
@@ -148,6 +148,11 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>3.5.3</version>
+                <configuration>
+                    <systemPropertyVariables>
+                        <maven.home>${maven.home}</maven.home>
+                    </systemPropertyVariables>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -158,6 +163,19 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.14.0</version>
+            </plugin>
+            <plugin>
+                <groupId>org.eclipse.sisu</groupId>
+                <artifactId>sisu-maven-plugin</artifactId>
+                <version>1.0.0</version>
+                <executions>
+                    <execution>
+                        <id>index-project</id>
+                        <goals>
+                            <goal>main-index</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/src/main/java/me/qoomon/maven/gitversioning/GitVersioningModelProcessor.java
+++ b/src/main/java/me/qoomon/maven/gitversioning/GitVersioningModelProcessor.java
@@ -62,7 +62,9 @@ import static org.slf4j.LoggerFactory.getLogger;
 @Singleton
 public class GitVersioningModelProcessor implements ModelProcessor {
 
-    private static final Pattern VERSION_PATTERN = Pattern.compile(".*?(?<version>(?<core>(?<major>\\d+)(?:\\.(?<minor>\\d+)(?:\\.(?<patch>\\d+))?)?)(?:-(?<label>.*))?)|");
+    static final Pattern VERSION_PATTERN = Pattern.compile(".*?(?<version>(?<core>(?<major>\\d+)(?:\\.(?<minor>\\d+)(?:\\.(?<patch>\\d+))?)?)(?:\\.(?<build>\\d+))?(?:-(?<label>.*))?)|");
+
+    private static final Pattern LABEL_TRAILING_NUM = Pattern.compile("^(.*?)(\\d*)$");
 
     private static final String OPTION_NAME_GIT_REF = "git.ref";
     private static final String OPTION_NAME_GIT_TAG = "git.tag";
@@ -874,11 +876,16 @@ public class GitVersioningModelProcessor implements ModelProcessor {
         placeholderMap.put("version.patch", Lazy.by(() -> requireNonNullElse(versionComponents.get().group("patch"), "0")));
         placeholderMap.put("version.patch.next", Lazy.by(() -> increase(placeholderMap.get("version.patch").get(), 1)));
 
+        placeholderMap.put("version.build", Lazy.by(() -> requireNonNullElse(versionComponents.get().group("build"), "")));
+        placeholderMap.put("version.build.next", Lazy.by(() -> increase(placeholderMap.get("version.build").get(), 1)));
+
         placeholderMap.put("version.label", Lazy.by(() -> requireNonNullElse(versionComponents.get().group("label"), "")));
         placeholderMap.put("version.label.prefixed", Lazy.by(() -> {
             String label = placeholderMap.get("version.label").get();
             return !label.isEmpty() ? "-" + label : "";
         }));
+
+        placeholderMap.put("version.next", Lazy.by(() -> nextVersion(versionComponents.get())));
 
         // deprecated
         placeholderMap.put("version.release", Lazy.by(() -> projectVersion.replaceFirst("-.*$", "")));
@@ -987,8 +994,13 @@ public class GitVersioningModelProcessor implements ModelProcessor {
         placeholderMap.put("describe.tag.version.patch", Lazy.by(() -> requireNonNullElse(descriptionTagVersionMatcher.get().group("patch"), "0")));
         placeholderMap.put("describe.tag.version.patch.next", Lazy.by(() -> increase(placeholderMap.get("describe.tag.version.patch").get(), 1)));
 
+        placeholderMap.put("describe.tag.version.build", Lazy.by(() -> requireNonNullElse(descriptionTagVersionMatcher.get().group("build"), "")));
+        placeholderMap.put("describe.tag.version.build.next", Lazy.by(() -> increase(placeholderMap.get("describe.tag.version.build").get(), 1)));
+
         placeholderMap.put("describe.tag.version.label", Lazy.by(() -> requireNonNullElse(descriptionTagVersionMatcher.get().group("label"), "")));
         placeholderMap.put("describe.tag.version.label.next", Lazy.by(() -> increase(placeholderMap.get("describe.tag.version.label").get(), 1)));
+
+        placeholderMap.put("describe.tag.version.next", Lazy.by(() -> nextVersion(descriptionTagVersionMatcher.get())));
 
         final Lazy<Integer> descriptionDistance = Lazy.by(() -> description.get().getDistance());
         placeholderMap.put("describe.distance", Lazy.by(() -> String.valueOf(descriptionDistance.get())));
@@ -996,6 +1008,9 @@ public class GitVersioningModelProcessor implements ModelProcessor {
 
         placeholderMap.put("describe.tag.version.patch.plus.describe.distance", Lazy.by(() -> increase(placeholderMap.get("describe.tag.version.patch").get(), descriptionDistance.get())));
         placeholderMap.put("describe.tag.version.patch.next.plus.describe.distance", Lazy.by(() -> increase(placeholderMap.get("describe.tag.version.patch.next").get(), descriptionDistance.get())));
+
+        placeholderMap.put("describe.tag.version.build.plus.describe.distance", Lazy.by(() -> increase(placeholderMap.get("describe.tag.version.build").get(), descriptionDistance.get())));
+        placeholderMap.put("describe.tag.version.build.next.plus.describe.distance", Lazy.by(() -> increase(placeholderMap.get("describe.tag.version.build.next").get(), descriptionDistance.get())));
 
         placeholderMap.put("describe.tag.version.label.plus.describe.distance", Lazy.by(() -> increase(placeholderMap.get("describe.tag.version.label").get(), descriptionDistance.get())));
         placeholderMap.put("describe.tag.version.label.next.plus.describe.distance", Lazy.by(() -> increase(placeholderMap.get("describe.tag.version.label.next").get(), descriptionDistance.get())));
@@ -1475,5 +1490,24 @@ public class GitVersioningModelProcessor implements ModelProcessor {
     private static String increase(String number, long increment) {
         String sanitized = number.isEmpty() ? "0" : number;
         return String.format("%0" + sanitized.length() + "d", Long.parseLong(number.isEmpty() ? "0" : number) + increment);
+    }
+
+    static String nextVersion(Matcher m) {
+        String label = m.group("label");
+        if (label != null && !label.isEmpty()) {
+            Matcher tail = LABEL_TRAILING_NUM.matcher(label);
+            tail.matches();
+            String coreAndBuild = m.group("core") + (m.group("build") != null ? "." + m.group("build") : "");
+            return coreAndBuild + "-" + tail.group(1) + increase(tail.group(2), 1);
+        }
+        if (m.group("build") != null) {
+            return m.group("major") + "." + m.group("minor") + "." + m.group("patch") + "." + increase(m.group("build"), 1);
+        } else if (m.group("patch") != null) {
+            return m.group("major") + "." + m.group("minor") + "." + increase(m.group("patch"), 1);
+        } else if (m.group("minor") != null) {
+            return m.group("major") + "." + increase(m.group("minor"), 1);
+        } else {
+            return increase(requireNonNullElse(m.group("major"), "0"), 1);
+        }
     }
 }

--- a/src/test/java/me/qoomon/maven/gitversioning/GitVersioningExtensionIT.java
+++ b/src/test/java/me/qoomon/maven/gitversioning/GitVersioningExtensionIT.java
@@ -25,6 +25,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 
@@ -33,6 +34,7 @@ import static me.qoomon.gitversioning.commons.GitRefType.TAG;
 import static me.qoomon.maven.gitversioning.GitVersioningModelProcessor.GIT_VERSIONING_POM_NAME;
 import static me.qoomon.maven.gitversioning.MavenUtil.readModel;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 import static org.eclipse.jgit.lib.Constants.MASTER;
 
@@ -70,8 +72,21 @@ class GitVersioningExtensionIT {
         verifier.verifyFileNotPresent(GIT_VERSIONING_POM_NAME);
     }
 
-    private static Verifier getVerifier(Path projectDir) throws VerificationException {
-        return new Verifier(projectDir.toFile().getAbsolutePath(), true);
+    private static Verifier getVerifier(Path projectDir) throws Exception {
+        Path settingsFile = writeIsolatedSettings(projectDir);
+        Verifier verifier = new Verifier(projectDir.toFile().getAbsolutePath(), settingsFile.toString(), true);
+        verifier.addCliArguments("-s", settingsFile.toString());
+        return verifier;
+    }
+
+    private static Path writeIsolatedSettings(Path projectDir) throws IOException {
+        Path settingsFile = projectDir.resolve("test-settings.xml");
+        Path localRepo = Paths.get(System.getProperty("user.home"), ".m2", "repository");
+        Files.write(settingsFile, ("" +
+                "<settings>\n" +
+                "  <localRepository>" + localRepo + "</localRepository>\n" +
+                "</settings>\n").getBytes());
+        return settingsFile;
     }
 
     @Test
@@ -374,9 +389,8 @@ class GitVersioningExtensionIT {
             }});
 
             // When
-            Verifier verifier = new Verifier(projectDir.toFile().getAbsolutePath()) {{
-                setEnvironmentVariable("VERSIONING_GIT_BRANCH", "v1.0.0");
-            }};
+            Verifier verifier = getVerifier(projectDir);
+            verifier.setEnvironmentVariable("VERSIONING_GIT_BRANCH", "v1.0.0");
             verifier.addCliArgument("verify");
             verifier.execute();
 
@@ -1035,6 +1049,200 @@ class GitVersioningExtensionIT {
         }
     }
 
+    @Test
+    void apply_UseDescribeTagVersion_FourSegmentIncluded() throws Exception {
+        assertDescribeTagVersionResolves("1.0.0.3", "${describe.tag.version}", "1.0.0.3");
+    }
+
+    @Test
+    void apply_UseDescribeTagVersionBuild() throws Exception {
+        assertDescribeTagVersionResolves("1.0.0.3", "${describe.tag.version.build}", "3");
+    }
+
+    @Test
+    void apply_UseDescribeTagVersionBuildNext() throws Exception {
+        assertDescribeTagVersionResolves("1.0.0.3", "${describe.tag.version.build.next}", "4");
+    }
+
+    @Test
+    void apply_UseDescribeTagVersionBuild_threeSegmentTag() throws Exception {
+        assertDescribeTagVersionResolves("1.0.0", "${describe.tag.version.build.next}", "1");
+    }
+
+    @Test
+    void apply_UseDescribeTagVersionBuildPlusDistance() throws Exception {
+        assertDescribeTagVersionResolvesWithDistance("1.0.0.3", 2, "${describe.tag.version.build.plus.describe.distance}", "5");
+    }
+
+    @Test
+    void apply_UseDescribeTagVersionBuildNextPlusDistance() throws Exception {
+        assertDescribeTagVersionResolvesWithDistance("1.0.0.3", 2, "${describe.tag.version.build.next.plus.describe.distance}", "6");
+    }
+
+    @Test
+    void apply_UseDescribeTagVersionNext_threeSegmentTag() throws Exception {
+        assertDescribeTagVersionResolves("1.2.3", "${describe.tag.version.next}", "1.2.4");
+    }
+
+    @Test
+    void apply_UseDescribeTagVersionNext_fourSegmentTag() throws Exception {
+        assertDescribeTagVersionResolves("1.2.3.4", "${describe.tag.version.next}", "1.2.3.5");
+    }
+
+    @Test
+    void apply_UseDescribeTagVersionNext_twoSegmentTag() throws Exception {
+        assertDescribeTagVersionResolves("1.2", "${describe.tag.version.next}", "1.3");
+    }
+
+    @Test
+    void apply_UseDescribeTagVersionNext_labelWithTrailingNum() throws Exception {
+        assertDescribeTagVersionResolves("1.2.3-RC1", "${describe.tag.version.next}", "1.2.3-RC2");
+    }
+
+    @Test
+    void apply_UseDescribeTagVersionNext_labelWithMultiDigitNum() throws Exception {
+        assertDescribeTagVersionResolves("1.2.3-RC10", "${describe.tag.version.next}", "1.2.3-RC11");
+    }
+
+    @Test
+    void apply_UseDescribeTagVersionNext_labelNoTrailingNum() throws Exception {
+        assertDescribeTagVersionResolves("1.2.3-alpha", "${describe.tag.version.next}", "1.2.3-alpha1");
+    }
+
+    @Test
+    void apply_UseDescribeTagVersionNext_fourSegmentWithLabel() throws Exception {
+        assertDescribeTagVersionResolves("1.2.3.4-RC1", "${describe.tag.version.next}", "1.2.3.4-RC2");
+    }
+
+    @Test
+    void apply_UseVersionBuild() throws Exception {
+        pomModel.setVersion("1.0.0.3-SNAPSHOT");
+        assertProjectVersionResolves("${version.build}", "3");
+    }
+
+    @Test
+    void apply_UseVersionBuildNext() throws Exception {
+        pomModel.setVersion("1.0.0.3-SNAPSHOT");
+        assertProjectVersionResolves("${version.build.next}", "4");
+    }
+
+    @Test
+    void apply_UseVersionNext_threeSegment() throws Exception {
+        pomModel.setVersion("1.2.3");
+        assertProjectVersionResolves("${version.next}", "1.2.4");
+    }
+
+    @Test
+    void apply_UseVersionNext_fourSegment() throws Exception {
+        pomModel.setVersion("1.2.3.4");
+        assertProjectVersionResolves("${version.next}", "1.2.3.5");
+    }
+
+    @Test
+    void apply_VersionBuildGroup_inProjectVersionPattern_throws() throws Exception {
+        assertProjectVersionPatternGroupCollides("build");
+    }
+
+    @Test
+    void apply_VersionNextGroup_inProjectVersionPattern_throws() throws Exception {
+        assertProjectVersionPatternGroupCollides("next");
+    }
+
+    // -----------------------------------------------------------------------------------------------------------------
+
+    private void assertDescribeTagVersionResolves(String tagName, String versionTemplate, String expectedVersion) throws Exception {
+        try (Git git = Git.init().setInitialBranch("master").setDirectory(projectDir.toFile()).call()) {
+            git.commit().setMessage("initial commit").setAllowEmpty(true).call();
+            git.tag().setAnnotated(true).setName(tagName).call();
+
+            writeModel(projectDir.resolve("pom.xml").toFile(), pomModel);
+            writeExtensionsFile(projectDir);
+            writeExtensionConfigFile(projectDir, new Configuration() {{
+                refs.list.add(createVersionDescription(BRANCH, versionTemplate));
+            }});
+
+            Verifier verifier = getVerifier(projectDir);
+            verifier.addCliArgument("verify");
+            verifier.execute();
+
+            System.err.println(String.join("\n", verifier.loadFile(verifier.getBasedir(), verifier.getLogFileName(), false)));
+            verifier.verifyErrorFreeLog();
+            verifier.verifyTextInLog("Building " + pomModel.getArtifactId() + " " + expectedVersion);
+
+            Model gitVersionedPomModel = readModel(projectDir.resolve(GIT_VERSIONING_POM_NAME).toFile());
+            assertThat(gitVersionedPomModel.getVersion()).isEqualTo(expectedVersion);
+        }
+    }
+
+    private void assertDescribeTagVersionResolvesWithDistance(String tagName, int commitsPastTag, String versionTemplate, String expectedVersion) throws Exception {
+        try (Git git = Git.init().setInitialBranch("master").setDirectory(projectDir.toFile()).call()) {
+            git.commit().setMessage("initial commit").setAllowEmpty(true).call();
+            git.tag().setAnnotated(true).setName(tagName).call();
+            for (int i = 0; i < commitsPastTag; i++) {
+                git.commit().setMessage("commit " + (i + 1)).setAllowEmpty(true).call();
+            }
+
+            writeModel(projectDir.resolve("pom.xml").toFile(), pomModel);
+            writeExtensionsFile(projectDir);
+            writeExtensionConfigFile(projectDir, new Configuration() {{
+                refs.list.add(createVersionDescription(BRANCH, versionTemplate));
+            }});
+
+            Verifier verifier = getVerifier(projectDir);
+            verifier.addCliArgument("verify");
+            verifier.execute();
+
+            System.err.println(String.join("\n", verifier.loadFile(verifier.getBasedir(), verifier.getLogFileName(), false)));
+            verifier.verifyErrorFreeLog();
+            verifier.verifyTextInLog("Building " + pomModel.getArtifactId() + " " + expectedVersion);
+
+            Model gitVersionedPomModel = readModel(projectDir.resolve(GIT_VERSIONING_POM_NAME).toFile());
+            assertThat(gitVersionedPomModel.getVersion()).isEqualTo(expectedVersion);
+        }
+    }
+
+    private void assertProjectVersionResolves(String versionTemplate, String expectedVersion) throws Exception {
+        try (Git git = Git.init().setInitialBranch("master").setDirectory(projectDir.toFile()).call()) {
+            git.commit().setMessage("initial commit").setAllowEmpty(true).call();
+
+            writeModel(projectDir.resolve("pom.xml").toFile(), pomModel);
+            writeExtensionsFile(projectDir);
+            writeExtensionConfigFile(projectDir, new Configuration() {{
+                refs.list.add(createVersionDescription(BRANCH, versionTemplate));
+            }});
+
+            Verifier verifier = getVerifier(projectDir);
+            verifier.addCliArgument("verify");
+            verifier.execute();
+
+            System.err.println(String.join("\n", verifier.loadFile(verifier.getBasedir(), verifier.getLogFileName(), false)));
+            verifier.verifyErrorFreeLog();
+            verifier.verifyTextInLog("Building " + pomModel.getArtifactId() + " " + expectedVersion);
+
+            Model gitVersionedPomModel = readModel(projectDir.resolve(GIT_VERSIONING_POM_NAME).toFile());
+            assertThat(gitVersionedPomModel.getVersion()).isEqualTo(expectedVersion);
+        }
+    }
+
+    private void assertProjectVersionPatternGroupCollides(String groupName) throws Exception {
+        try (Git git = Git.init().setInitialBranch("master").setDirectory(projectDir.toFile()).call()) {
+            git.commit().setMessage("initial commit").setAllowEmpty(true).call();
+
+            writeModel(projectDir.resolve("pom.xml").toFile(), pomModel);
+            writeExtensionsFile(projectDir);
+            writeExtensionConfigFile(projectDir, new Configuration() {{
+                projectVersionPattern = "(?<" + groupName + ">\\d+).*";
+                refs.list.add(createVersionDescription(BRANCH, "${version}"));
+            }});
+
+            Verifier verifier = getVerifier(projectDir);
+            verifier.addCliArgument("verify");
+
+            assertThatThrownBy(verifier::execute).isInstanceOf(VerificationException.class);
+            verifier.verifyTextInLog("project version pattern capture group can not be named '" + groupName + "'");
+        }
+    }
+
     // -----------------------------------------------------------------------------------------------------------------
 
     private File writeExtensionsFile(Path projectDir) throws IOException {
@@ -1044,7 +1252,7 @@ class GitVersioningExtensionIT {
                 "  <extension>\n" +
                 "    <groupId>me.qoomon</groupId>\n" +
                 "    <artifactId>maven-git-versioning-extension</artifactId>\n" +
-                "    <version>LATEST</version>\n" +
+                "    <version>" + BuildProperties.projectVersion() + "</version>\n" +
                 "  </extension>\n" +
                 "</extensions>").getBytes()).toFile();
     }

--- a/src/test/java/me/qoomon/maven/gitversioning/GitVersioningModelProcessorTest.java
+++ b/src/test/java/me/qoomon/maven/gitversioning/GitVersioningModelProcessorTest.java
@@ -1,0 +1,111 @@
+package me.qoomon.maven.gitversioning;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.regex.Matcher;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class GitVersioningModelProcessorTest {
+
+    @Test
+    void versionPattern_matchesFourSegmentTag() {
+        Matcher m = match("1.0.0.3");
+        assertThat(m.group("version")).isEqualTo("1.0.0.3");
+        assertThat(m.group("core")).isEqualTo("1.0.0");
+        assertThat(m.group("major")).isEqualTo("1");
+        assertThat(m.group("minor")).isEqualTo("0");
+        assertThat(m.group("patch")).isEqualTo("0");
+        assertThat(m.group("build")).isEqualTo("3");
+        assertThat(m.group("label")).isNull();
+    }
+
+    @Test
+    void versionPattern_matchesThreeSegmentTag_buildIsNull() {
+        Matcher m = match("1.0.0");
+        assertThat(m.group("version")).isEqualTo("1.0.0");
+        assertThat(m.group("core")).isEqualTo("1.0.0");
+        assertThat(m.group("build")).isNull();
+        assertThat(m.group("label")).isNull();
+    }
+
+    @Test
+    void versionPattern_matchesFourSegmentWithLabel() {
+        Matcher m = match("1.2.3.4-RC1");
+        assertThat(m.group("version")).isEqualTo("1.2.3.4-RC1");
+        assertThat(m.group("core")).isEqualTo("1.2.3");
+        assertThat(m.group("build")).isEqualTo("4");
+        assertThat(m.group("label")).isEqualTo("RC1");
+    }
+
+    @Test
+    void versionPattern_matchesThreeSegmentWithLabel_buildStillNull() {
+        Matcher m = match("1.2.3-alpha");
+        assertThat(m.group("version")).isEqualTo("1.2.3-alpha");
+        assertThat(m.group("core")).isEqualTo("1.2.3");
+        assertThat(m.group("build")).isNull();
+        assertThat(m.group("label")).isEqualTo("alpha");
+    }
+
+    @Test
+    void nextVersion_threeSegment() {
+        assertNextVersion("1.2.3", "1.2.4");
+    }
+
+    @Test
+    void nextVersion_fourSegment() {
+        assertNextVersion("1.2.3.4", "1.2.3.5");
+    }
+
+    @Test
+    void nextVersion_twoSegment() {
+        assertNextVersion("1.2", "1.3");
+    }
+
+    @Test
+    void nextVersion_singleSegment() {
+        assertNextVersion("1", "2");
+    }
+
+    @Test
+    void nextVersion_labelWithTrailingNum() {
+        assertNextVersion("1.2.3-RC1", "1.2.3-RC2");
+    }
+
+    @Test
+    void nextVersion_labelWithMultiDigitNum() {
+        assertNextVersion("1.2.3-RC10", "1.2.3-RC11");
+    }
+
+    @Test
+    void nextVersion_labelNoTrailingNum() {
+        assertNextVersion("1.2.3-alpha", "1.2.3-alpha1");
+    }
+
+    @Test
+    void nextVersion_snapshotLabel() {
+        assertNextVersion("1.2.3-SNAPSHOT", "1.2.3-SNAPSHOT1");
+    }
+
+    @Test
+    void nextVersion_fourSegmentWithLabel() {
+        assertNextVersion("1.2.3.4-RC1", "1.2.3.4-RC2");
+    }
+
+    @Test
+    void nextVersion_onlyTrailingDigitsInLabelAreBumped() {
+        assertNextVersion("1.2.3-RC1-final", "1.2.3-RC1-final1");
+    }
+
+    private static void assertNextVersion(String input, String expected) {
+        assertThat(GitVersioningModelProcessor.nextVersion(match(input)))
+                .as("nextVersion(%s)", input)
+                .isEqualTo(expected);
+    }
+
+    private static Matcher match(String input) {
+        Matcher m = GitVersioningModelProcessor.VERSION_PATTERN.matcher(input);
+        m.find();
+        return m;
+    }
+}


### PR DESCRIPTION
Resolves #412.

Adds an optional 4th `.build` dot-segment to the version regex (e.g. `3.0.28.1` is now parsed as major=3, minor=0, patch=28, build=1) plus new placeholders for accessing and bumping it. Also adds a shape-aware version-increment placeholder that picks the segment to bump based on the tag's actual shape, so a single template can handle both 3- and 4-segment tags.

## New placeholders for the 4th `.build` segment

- `${describe.tag.version.build}` / `${describe.tag.version.build.next}`
- `${describe.tag.version.build.plus.describe.distance}` / `${describe.tag.version.build.next.plus.describe.distance}`
- `${version.build}` / `${version.build.next}`

## New `${...version.next}` placeholders (shape-aware version increment)

`${describe.tag.version.next}` and `${version.next}` bump one numeric segment of the parsed version, picking which segment based on the version's shape:

- trailing numeric in the label (`RC1` → `RC2`, `RC10` → `RC11`)
- label with no trailing numeric, treated as `0` (`alpha` → `alpha1`)
- otherwise the rightmost numeric core segment

This is strictly more capable than the existing `${...label.next}` for RC-style labels: the latter calls `Long.parseLong` on the whole label and currently throws on values like `RC1`.

## Behavior change

`${describe.tag.version}` for tags with a 4th dot-segment now returns the full string. Previously a tag like `3.0.28.1` resolved to `3.0.28` (silently truncated). 3-segment tags are unaffected. `${version}` is unchanged — it returns the raw project `<version>` and never went through the regex.

## Build infrastructure

- Add `sisu-maven-plugin:main-index` so locally-built jars include `META-INF/sisu/javax.inject.Named` and Maven can discover the extension's `@Named` classes via the Sisu container.
- Configure surefire to forward `${maven.home}` to forked test JVMs so the IT `Verifier` can find Maven without relying on PATH.
- IT framework writes an isolated `test-settings.xml` (no mirror, absolute local repository) and pins the extension version via `BuildProperties.projectVersion()` instead of `LATEST`. ITs are now deterministic and self-contained regardless of the user's settings.xml.

Version bumped 9.11.0 → 9.12.0.